### PR TITLE
Reporter "methods"

### DIFF
--- a/lib/nerve.rb
+++ b/lib/nerve.rb
@@ -6,7 +6,6 @@ require 'nerve/version'
 require 'nerve/utils'
 require 'nerve/log'
 require 'nerve/ring_buffer'
-require 'nerve/reporter'
 require 'nerve/service_watcher'
 
 module Nerve

--- a/lib/nerve/reporter/zookeeper.rb
+++ b/lib/nerve/reporter/zookeeper.rb
@@ -6,6 +6,10 @@ module Nerve
     include Logging
 
     def initialize(opts)
+      # Maintain compatibility with configs
+      opts['hosts'] ||= opts['zk_hosts']
+      opts['path'] ||= opts['zk_path']
+
       %w{hosts path key}.each do |required|
         raise ArgumentError, "you need to specify required argument #{required}" unless opts[required]
       end

--- a/lib/nerve/reporter/zookeeper.rb
+++ b/lib/nerve/reporter/zookeeper.rb
@@ -1,7 +1,7 @@
 require 'zk'
 
 module Nerve
-  class Reporter
+  class ZookeeperReporter
     include Utils
     include Logging
 

--- a/lib/nerve/reporter/zookeeper.rb
+++ b/lib/nerve/reporter/zookeeper.rb
@@ -6,16 +6,13 @@ module Nerve
     include Logging
 
     def initialize(opts)
-      # Maintain compatibility with configs
-      opts['hosts'] ||= opts['zk_hosts']
-      opts['path'] ||= opts['zk_path']
 
-      %w{hosts path key}.each do |required|
+      %w{zk_hosts zk_path key}.each do |required|
         raise ArgumentError, "you need to specify required argument #{required}" unless opts[required]
       end
 
-      @path = opts['hosts'].shuffle.join(',') + opts['path']
-      @data = parse_data(opts['data'] || '')
+      @path = opts['zk_hosts'].shuffle.join(',') + opts['zk_path']
+      @data = parse_data({'host' => service['host'], 'port' => service['port']})
       @key = opts['key']
       @key.insert(0,'/') unless @key[0] == '/'
     end

--- a/lib/nerve/service_watcher.rb
+++ b/lib/nerve/service_watcher.rb
@@ -30,9 +30,8 @@ module Nerve
       meth = service['method'] || 'zookeeper'
 
       unless @reporters[meth]
-        if m = service['module']
-          require m
-        end
+        m = service['module'] ? service['module'] : "nerve-reporter-#{meth}"
+        require m
       end
 
       @reporter = @reporters[meth].new(


### PR DESCRIPTION
Simple (and untested) indirection between the core and reporters based on how its done in synapse.  Should allow non-zk reporters to be added in the future.  

Quick code - just wanted to get the idea out there. I'm interested in using etcd with expiring keys rather than zk.