### PR TITLE
allow a no-watchers state

### DIFF
--- a/lib/nerve.rb
+++ b/lib/nerve.rb
@@ -15,17 +15,10 @@ module Nerve
     include Logging
 
     def initialize(opts={})
+      log.info 'nerve: starting up!'
+
       # set global variable for exit signal
       $EXIT = false
-
-      # trap int signal and set exit to true
-      %w{INT TERM}.each do |signal|
-        trap(signal) do
-          $EXIT = true
-        end
-      end
-
-      log.info 'nerve: starting up!'
 
       # required options
       log.debug 'nerve: checking for required inputs'
@@ -34,36 +27,43 @@ module Nerve
       end
 
       @instance_id = opts['instance_id']
-
-      # create service watcher objects
-      log.debug 'nerve: creating service watchers'
-      @service_watchers=[]
-      opts['services'].each do |name, config|
-        @service_watchers << ServiceWatcher.new(config.merge({'instance_id' => @instance_id, 'name' => name}))
-      end
+      @services = opts['services']
+      @watchers = {}
 
       log.debug 'nerve: completed init'
     end
 
     def run
       log.info 'nerve: starting run'
-      begin
-        children = []
 
-        log.debug 'nerve: launching service check threads'
-        @service_watchers.each do |watcher|
-          children << Thread.new{watcher.run}
-        end
-
-        log.debug 'nerve: main thread done, waiting for children'
-        children.each do |child|
-          child.join
-        end
-      ensure
-        $EXIT = true
+      @services.each do |name, config|
+        launch_watcher(name, config)
       end
+
+      begin
+        sleep
+      rescue
+        log.debug 'nerve: sleep interrupted; exiting'
+        $EXIT = true
+        @watchers.each do |name, watcher_thread|
+          reap_watcher(name)
+        end
+      end
+
       log.info 'nerve: exiting'
+    ensure
+      $EXIT = true
     end
 
+    def launch_watcher(name, config)
+      log.debug "nerve: launching service watcher #{name}"
+      watcher = ServiceWatcher.new(config.merge({'instance_id' => @instance_id, 'name' => name}))
+      @watchers[name] = Thread.new{watcher.run}
+    end
+
+    def reap_watcher(name)
+      watcher_thread = @watchers.delete(name)
+      watcher_thread.join()
+    end
   end
 end


### PR DESCRIPTION
in order to support the use case of dynamic registration, nerve should continue
running even if it was started with no services defined in it's config. this
re-structures the main thread to make that possible.

the main action of the main thread is to sleep, waiting for an interrupt. an
interrupt triggers the reaping of existing watchers, of which there may be
none.

as a byproduct, we create an interface to add additional watchers dynamically.
a hypothetical future TCP server can call `launch_watcher` on the main class to
register a new watcher. similarly, it can call `reap_watcher` to kill a watcher.

@brndnmtthws maybe this could be the basis of your new API?
this is not yet tested. working on additional tests around exiting/signal handling in smartstack-cookbook
