### PR TITLE
postgresql_service_watcher: created a new basic postgresql service watcher 

### DIFF
--- a/example/nerve.conf.json
+++ b/example/nerve.conf.json
@@ -45,6 +45,21 @@
           "password": "guest"
         }
       ]
+    },
+    "postgresql_service": {
+      "port": 4321,
+      "host": "127.0.0.1",
+      "zk_hosts": ["localhost:2181"],
+      "zk_path": "/nerve/services/your_postgresql_service/services",
+      "check_interval": 2,
+      "checks": [
+        {
+          "type": "postgresql",
+          "dbname": "dbname",
+          "user": "guest",
+          "password": "guest"
+        }
+      ]
     }
   }
 }

--- a/lib/nerve/service_watcher.rb
+++ b/lib/nerve/service_watcher.rb
@@ -1,6 +1,7 @@
 require 'nerve/service_watcher/tcp'
 require 'nerve/service_watcher/http'
 require 'nerve/service_watcher/rabbitmq'
+require 'nerve/service_watcher/rabbitmq'
 
 module Nerve
   class ServiceWatcher

--- a/lib/nerve/service_watcher/postgresql.rb
+++ b/lib/nerve/service_watcher/postgresql.rb
@@ -1,0 +1,52 @@
+require 'nerve/service_watcher/base'
+require 'pg'
+
+module Nerve
+  module ServiceCheck
+    class PostgreSQLServiceCheck < BaseServiceCheck
+      require 'socket'
+      include Socket::Constants
+
+      def initialize(opts={})
+        super
+
+        raise ArgumentError, "missing required arguments in postgresql check" unless opts['port'] and opts['user']
+
+        @port = opts['port']
+        @host = opts['host']
+        @dbname = opts['dbname']
+        @user = opts['user']
+        @password = opts['password']
+      end
+
+      def check
+        # The best way to check postgresql is alive to query
+        log.debug "nerve: running @host = opts['host'] health check #{@name}"
+
+        conn = PGconn.new(
+          :host => @host,
+          :port => @port,
+          :dbname => @dbname,
+          :user => @user,
+          :password => @password
+        )
+
+        begin
+          res = conn.exec('select 1')
+          data = res.getvalue(0,0)
+          if data
+            return true
+          else
+            log.debug "nerve: postgresql failed to responde"
+            return false
+          end
+        ensure
+          conn.close
+        end
+      end
+    end
+
+    CHECKS ||= {}
+    CHECKS['postgresql'] = PostgreSQLServiceCheck
+  end
+end

--- a/nerve.gemspec
+++ b/nerve.gemspec
@@ -19,4 +19,5 @@ Gem::Specification.new do |gem|
 
   gem.add_runtime_dependency "zk", "~> 1.9.2"
   gem.add_runtime_dependency "bunny", "= 1.0.0.rc2"
+  gem.add_runtime_dependency "pg", "= 0.17.0"
 end


### PR DESCRIPTION
There is a new dependency for postgresql so need to execute `bundle install` in nerve environment, if installation fails install `sudo apt-get install libpq-dev` and then re-install gem

For more details:
[How to use ruby environment for Nerve and Synapse](https://github.com/dubizzle/smartstack-cookbook/wiki/How-to-use-ruby-environment-for-Nerve-and-Synapse)
