### PR TITLE
use YAML rather than JSON for configuration files

### DIFF
--- a/bin/nerve
+++ b/bin/nerve
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 
-require 'json'
+require 'yaml'
 require 'optparse'
 
 require 'nerve'
@@ -34,13 +34,13 @@ optparse.parse!
 def parseconfig(filename)
   # parse synapse config file
   begin
-    c = JSON::parse(File.read(filename))
+    c = YAML::parse(File.read(filename))
   rescue Errno::ENOENT => e
     raise ArgumentError, "config file does not exist:\n#{e.inspect}"
   rescue Errno::EACCES => e
     raise ArgumentError, "could not open config file:\n#{e.inspect}"
-  rescue JSON::ParserError => e
-    raise "config file #{filename} is not json:\n#{e.inspect}"
+  rescue YAML::ParseError => e
+    raise "config file #{filename} is not yaml:\n#{e.inspect}"
   end
   return c
 end
@@ -53,8 +53,8 @@ if config.has_key?('service_conf_dir')
   if ! Dir.exists?(cdir) then
     raise "service conf dir does not exist:#{cdir}"
   end
-  cfiles = Dir.glob(File.join(cdir, '*.json'))
-  cfiles.each { |x| config['services'][File.basename(x[/(.*)\.json$/, 1])] = parseconfig(x) }
+  cfiles = Dir.glob(File.join(cdir, '*.{yaml,json}'))
+  cfiles.each { |x| config['services'][File.basename(x[/(.*)\.(yaml|json)$/, 1])] = parseconfig(x) }
 end
 
 # create nerve object


### PR DESCRIPTION
JSON is an excellent tool for simple data interchange between servers,
but is a royal pain as a configuration file format which must also be
written and read by human beings.  The difference between valid and
invalid JSON is often down to a single character in hard-to-spot places:

```
{ "valid_json?":
  { "lets":
    ["play",
     "spot",
     "the",
     "syntax",
     "errors",
   ]
  },
}
```

(It gets even worse if you want to _generate_ valid JSON in the context
of, say, an ERB/moustache template file: ugly logic must be invoked to
make sure that lists are terminated correctly.)

Even worse: correct JSON does not allow for comments. And while you can
certainly do:

```
{ "this_dict": {
    "has": "values",
    "and": "a",
    "comment": "which is me!" }
}
```

...it's much harder to do something like this:

```
{ "this_dict": {
    # TODO: restore when bug #7 closes
    # "has": "values",
    # "and": "a",
    "comment": "which is me!" }
}
```

...whereas all of the above strings are valid and correct YAML.
