### PR TITLE
Adding possibility to add admin_port value, and also report it to ZK.

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ The key is the name of the service, and the value is a configuration hash tellin
 The configuration contains the following options:
 
 * `port`: the default port for service checks; nerve will submit this the address `instance_id:port` to Zookeeper
+* `admin_port`: (optional) override the default port for service checks; setting this it will be reported to Zookeeper as `"admin_port": "<value>"`. If you don't want the port to show up in Zookeeper use the override in the check instead
 * `host`: the default host on which to make service checks; you should make this your *public* ip if you want to make sure your service is publically accessible
 * `zk_hosts`: a list of the zookeeper hosts comprising the [ensemble](https://zookeeper.apache.org/doc/r3.1.2/zookeeperAdmin.html#sc_zkMulitServerSetup) that nerve will submit registration to
 * `zk_path`: the path (or [znode](https://zookeeper.apache.org/doc/r3.1.2/zookeeperProgrammers.html#sc_zkDataModel_znodes)) where the registration will be created; nerve will create the [ephemeral node](https://zookeeper.apache.org/doc/r3.1.2/zookeeperProgrammers.html#Ephemeral+Nodes) that is the registration as a child of this path
@@ -62,7 +63,7 @@ Although the exact parameters passed to each check are different, all take a num
 * `type`: (required) the kind of check; you can see available check types in the `lib/nerve/service_watcher` dir of this repo
 * `name`: (optional) a descriptive, human-readable name for the check; it will be auto-generated based on the other parameters if not specified
 * `host`: (optional) the host on which the check will be performed; defaults to the `host` of the service to which the check belongs
-* `port`: (optional) the port on which the check will be performed; like `host`, it defaults to the `port` of the service
+* `port`: (optional) the port on which the check will be performed; like `host`, it defaults to the `port` of the service (or `admin_port` if set)
 * `timeout`: (optional) maximum time the check can take; defaults to `100ms`
 * `rise`: (optional) how many consecutive checks must pass before the check is considered passing; defaults to 1
 * `fall`: (optional) how many consecutive checks must fail before the check is considered failing; defaults to 1

--- a/example/nerve.conf.json
+++ b/example/nerve.conf.json
@@ -4,6 +4,7 @@
   "services": {
     "your_http_service": {
       "port": 3000,
+      "admin_port": 3001,
       "host": "127.0.0.1",
       "zk_hosts": ["localhost:2181"],
       "zk_path": "/nerve/services/your_http_service/services",

--- a/lib/nerve/service_watcher.rb
+++ b/lib/nerve/service_watcher.rb
@@ -17,13 +17,17 @@ module Nerve
 
       @name = service['name']
 
-      # configure the reporter, which we use for talking to zookeeper
+      # configure the reporter, which we use for talking to zookeeper - adding conditional admin-port (removed if nil)
       @reporter = Reporter.new({
           'hosts' => service['zk_hosts'],
           'path' => service['zk_path'],
           'key' => "#{service['instance_id']}_#{@name}",
-          'data' => {'host' => service['host'], 'port' => service['port']},
-        })
+          'data' => {
+              'host' => service['host'],
+              'port' => service['port'],
+              'admin_port' => service['admin_port']
+          }.reject { |k, v| v.nil? },
+      })
 
       # instantiate the checks for this service
       @service_checks = []
@@ -38,7 +42,7 @@ module Nerve
         end
 
         check['host'] ||= service['host']
-        check['port'] ||= service['port']
+        check['port'] ||= service['admin_port'] || service['port']
         check['name'] ||= "#{@name} #{check['type']}-#{check['host']}:#{check['port']}"
         @service_checks << service_check_class.new(check)
       end


### PR DESCRIPTION
We are evaluating SmartStack (Nerve/Synapse/HAProxy) in our products, and since we are using Dropwizard/Metrics extensively we need to be able to do the checkon  another port. 

Now this is already possible by override the port in the checks, but I also need to make the admin port available in Zookeeper as we are building a service to keep track of all running services and their state. To do that we need to get hold of the admin port in addition to the regular traffic port.

Not a daily rubyist, so hopefully my coding is up to your standards. If it is not, I will not be offended :-)

Hopefully this scratches someone elses back as well.
