### PR TITLE
Use bunny 1.0.0 instead of rc2

### DIFF
--- a/nerve.gemspec
+++ b/nerve.gemspec
@@ -18,5 +18,5 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
 
   gem.add_runtime_dependency "zk", "~> 1.9.2"
-  gem.add_runtime_dependency "bunny", "= 1.0.0.rc2"
+  gem.add_runtime_dependency "bunny", "= 1.0.0"
 end


### PR DESCRIPTION
For the dependency on bunny, there doesn't seem like a good reason to use 1.0.0rc2, so I've bumped the version up to 1.0.0
