### PR TITLE
log service watcher errors when not in debug mode

### DIFF
--- a/lib/nerve/service_watcher/base.rb
+++ b/lib/nerve/service_watcher/base.rb
@@ -16,7 +16,7 @@ module Nerve
 
       def up?
         # do the check
-        check_result = !!ignore_errors do
+        check_result = !!catch_errors do
           check
         end
 
@@ -44,6 +44,15 @@ module Nerve
 
         # otherwise return the last result
         return @last_result
+      end
+
+      def catch_errors(&block)
+        begin
+          return yield
+        rescue Object => error
+          log.info "nerve: service check #{@name} got error #{error.inspect}"
+          return false
+        end
       end
     end
   end

--- a/lib/nerve/service_watcher/http.rb
+++ b/lib/nerve/service_watcher/http.rb
@@ -31,10 +31,11 @@ module Nerve
         response = connection.get(@uri)
         code = response.code.to_i
 
-        log.debug "nerve: check #{@name} got response code #{code}"
         if code >= 200 and code < 300
+          log.debug "nerve: check #{@name} got response code #{code} with body \"#{response.body}\""
           return true
         else
+          log.error "nerve: check #{@name} got response code #{code} with body \"#{response.body}\""
           return false
         end
       end

--- a/lib/nerve/utils.rb
+++ b/lib/nerve/utils.rb
@@ -4,14 +4,5 @@ module Nerve
       res = `#{command}`.chomp
       raise "command '#{command}' failed to run:\n#{res}" unless $?.success?
     end
-
-    def ignore_errors(&block)
-      begin
-        return yield
-      rescue Object => error
-        log.debug "ignoring error #{error.inspect}"
-        return false
-      end
-    end
   end
 end


### PR DESCRIPTION
Currently, unless the log level is set to debug, nerve is silent as to _why_ a
service is marked unhealthy.  We should not have to spam the log files with
debug messages in order to find out why a service was marked down.
