### PR TITLE
Load a service check module if added to the config. 

### DIFF
--- a/lib/nerve/service_watcher.rb
+++ b/lib/nerve/service_watcher.rb
@@ -32,9 +32,9 @@ module Nerve
         check['type'] ||= "undefined"
         begin
           unless ServiceCheck::CHECKS[check['type']]
-            if m = check['module']
-              require m
-            end
+            m = check['module'] ? check['module'] : "nerve-watcher-#{check['type']}"
+            require m
+          end
           service_check_class = ServiceCheck::CHECKS[check['type']]
         rescue
           raise ArgumentError,

--- a/lib/nerve/service_watcher.rb
+++ b/lib/nerve/service_watcher.rb
@@ -31,6 +31,10 @@ module Nerve
       service['checks'].each do |check|
         check['type'] ||= "undefined"
         begin
+          unless ServiceCheck::CHECKS[check['type']]
+            if m = check['module']
+              require m
+            end
           service_check_class = ServiceCheck::CHECKS[check['type']]
         rescue
           raise ArgumentError,


### PR DESCRIPTION
This allows service checks to not have to be in core.

I see lots or PR's for adding service checks to nerve. They probably all do not belong in the core. This is a quick hack to load them at run time.  Probably not ideal.  We may could have a list of modules we want to load in the config maybe rather than per service??