### PR TITLE
update bunny to 1.1.0-release

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,9 +8,9 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    amq-protocol (1.8.0)
-    bunny (1.0.0.rc2)
-      amq-protocol (>= 1.8.0)
+    amq-protocol (1.9.2)
+    bunny (1.1.0)
+      amq-protocol (>= 1.9.2)
     little-plugger (1.1.3)
     logging (1.7.2)
       little-plugger (>= 1.1.3)

--- a/nerve.gemspec
+++ b/nerve.gemspec
@@ -18,5 +18,5 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
 
   gem.add_runtime_dependency "zk", "~> 1.9.2"
-  gem.add_runtime_dependency "bunny", "= 1.0.0.rc2"
+  gem.add_runtime_dependency "bunny", "= 1.1.0"
 end


### PR DESCRIPTION
Otherwise the following happens to rabbitmq watchers:

[2014-01-22T20:19:46.313550 #29832]  INFO -- Nerve::ServiceCheck::RabbitMQServiceCheck: nerve: service check rabbitmq rabbitmq-i-9334a2e3:40050 got error #<NoMethodError: undefined method `event_loop' for #<Bunny::Session:0x00000003469238>>
