### PR TITLE
Fix fail-fast behavior

### DIFF
--- a/lib/nerve.rb
+++ b/lib/nerve.rb
@@ -30,6 +30,10 @@ module Nerve
       @services = opts['services']
       @watchers = {}
 
+      # Any exceptions in the watcher threads should wake the main thread so
+      # that we can fail fast.
+      Thread.abort_on_exception = true
+
       log.debug 'nerve: completed init'
     end
 
@@ -43,7 +47,7 @@ module Nerve
       begin
         sleep
       rescue StandardError => e
-        log.error 'nerve: encountered unexpected exception #{e.inspect} in main thread'
+        log.error "nerve: encountered unexpected exception #{e.inspect} in main thread"
         raise e
       ensure
         $EXIT = true

--- a/lib/nerve/reporter/base.rb
+++ b/lib/nerve/reporter/base.rb
@@ -10,6 +10,9 @@ class Nerve::Reporter
     def start
     end
 
+    def stop
+    end
+
     def report_up
     end
 

--- a/lib/nerve/reporter/zookeeper.rb
+++ b/lib/nerve/reporter/zookeeper.rb
@@ -21,6 +21,11 @@ class Nerve::Reporter
       log.info "nerve: successfully created zk connection to #{@path}"
     end
 
+    def stop()
+      log.info "nerve: closing zk connection at #{@path}"
+      @zk.close
+    end
+
     def report_up()
       zk_save
     end

--- a/lib/nerve/service_watcher.rb
+++ b/lib/nerve/service_watcher.rb
@@ -72,11 +72,12 @@ module Nerve
         sleep @check_interval
       end
     rescue StandardError => e
-      log.error "nerve: error in service watcher #{@name}: #{e}"
+      log.error "nerve: error in service watcher #{@name}: #{e.inspect}"
       raise e
     ensure
       log.info "nerve: ending service watch #{@name}"
       $EXIT = true
+      @reporter.stop
     end
 
     def check?


### PR DESCRIPTION
- Actually wake the main thread in case of an exception in a reporter
- Properly cleanup after Zookeeper to avoid possible infinite sched_yield loop
  on exit
