### PR TITLE
bin/nerve: Update YAML exception handling to Psych semantics

### DIFF
--- a/bin/nerve
+++ b/bin/nerve
@@ -39,7 +39,7 @@ def parseconfig(filename)
     raise ArgumentError, "config file does not exist:\n#{e.inspect}"
   rescue Errno::EACCES => e
     raise ArgumentError, "could not open config file:\n#{e.inspect}"
-  rescue YAML::ParseError => e
+  rescue YAML::SyntaxError => e
     raise "config file #{filename} is not yaml:\n#{e.inspect}"
   end
   return c

--- a/bin/nerve
+++ b/bin/nerve
@@ -42,7 +42,7 @@ def parseconfig(filename)
   rescue YAML::SyntaxError => e
     raise "config file #{filename} is not yaml:\n#{e.inspect}"
   end
-  return c
+  return c.to_ruby
 end
 
 config = parseconfig(options[:config])


### PR DESCRIPTION
As noted here https://github.com/airbnb/synapse/issues/52#issuecomment-45909582 updating the bin/nerve script to follow the new Psych exception semantics in Ruby 1.9.3+, matching what synapse is now doing.

Note that this now means nerve will only run in Ruby 1.9.3+. If you want a more generic solution that works across all Ruby versions, let me know, but I just followed the lead of what was done in synapse.
