### PR TITLE
HTTP health check on a different port

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Although the exact parameters passed to each check are different, all take a num
 * `timeout`: (optional) maximum time the check can take; defaults to `100ms`
 * `rise`: (optional) how many consecutive checks must pass before the check is considered passing; defaults to 1
 * `fall`: (optional) how many consecutive checks must fail before the check is considered failing; defaults to 1
+* `http_port`: (optional) perform http health check on a port different from the one used for connection; defaults to the value of `port`
 
 ## Contributing
 

--- a/lib/nerve/service_watcher/http.rb
+++ b/lib/nerve/service_watcher/http.rb
@@ -20,12 +20,12 @@ module Nerve
         @read_timeout = opts['read_timeout'] || @timeout
         @open_timeout = opts['open_timeout'] || 0.2
         @ssl_timeout  = opts['ssl_timeout']  || 0.2
-
+        @http_port  = opts['http_port']  || @port
         @headers     = opts['headers'] || {}
 
         @expect      = opts['expect']
 
-        @name        = "http-#{@host}:#{@port}#{@uri}"
+        @name        = "http-#{@host}:#{@http_port}#{@uri}"
       end
 
       def check
@@ -47,7 +47,7 @@ module Nerve
 
       private
       def get_connection
-        con = Net::HTTP.new(@host, @port)
+        con = Net::HTTP.new(@host, @http_port)
         con.read_timeout = @read_timeout
         con.open_timeout = @open_timeout
 


### PR DESCRIPTION
Adds the ability to perform health checks on a custom port. 

Use case: Galera MySQL cluster with HTTP-check (MySQL port 3306 and HTTP check on port 80)

By default, does not change behavior - http_port = port