### PR TITLE
report_down when stopping ZK reporter.

### DIFF
--- a/lib/nerve/reporter/zookeeper.rb
+++ b/lib/nerve/reporter/zookeeper.rb
@@ -23,6 +23,7 @@ class Nerve::Reporter
 
     def stop()
       log.info "nerve: closing zk connection at #{@path}"
+      report_down
       @zk.close
     end
 

--- a/spec/lib/nerve/reporter_zookeeper_spec.rb
+++ b/spec/lib/nerve/reporter_zookeeper_spec.rb
@@ -13,5 +13,19 @@ describe Nerve::Reporter::Zookeeper do
   it 'actually constructs an instance' do
     expect(Nerve::Reporter::Zookeeper.new(subject).is_a?(Nerve::Reporter::Zookeeper)).to eql(true)
   end
+
+  it 'deregisters service on exit' do
+    zk = double("zk")
+    allow(zk).to receive(:close)
+    expect(zk).to receive(:create) { "full_path" }
+    expect(zk).to receive(:delete).with("full_path", anything())
+
+    ZK.stub(:new) { zk }
+
+    reporter = Nerve::Reporter::Zookeeper.new(subject)
+    reporter.start
+    reporter.report_up
+    reporter.stop
+  end
 end
 


### PR DESCRIPTION
While investigating using nerve & synapse at work, we stumbled across the fact that the ZK reporter doesn't automatically deregister the watched service on exit, but the etcd reporter does.

Our use case involves running a nerve instance within a docker image to get some nice automatic service discovery and a lifecycle that corresponds directly with that of the image -- if the image goes down, we want to make sure anything running within is reported as down.

I've added de-registering when stopping the ZK reporter and attempted to add a test that shows the expected lifecycle. I'm not a huge fan of it as it mocks literally everything, and is somewhat difficult to generalize to the etcd reporter as well.

Let me know what needs to be done to get this merged in. Thanks!
