### PR TITLE
Fix the ZK thread leak while closing connection.

### DIFF
--- a/lib/nerve/reporter/zookeeper.rb
+++ b/lib/nerve/reporter/zookeeper.rb
@@ -24,7 +24,7 @@ class Nerve::Reporter
     def stop()
       log.info "nerve: closing zk connection at #{@path}"
       report_down
-      @zk.close
+      @zk.close!
     end
 
     def report_up()

--- a/spec/lib/nerve/reporter_zookeeper_spec.rb
+++ b/spec/lib/nerve/reporter_zookeeper_spec.rb
@@ -16,7 +16,7 @@ describe Nerve::Reporter::Zookeeper do
 
   it 'deregisters service on exit' do
     zk = double("zk")
-    allow(zk).to receive(:close)
+    allow(zk).to receive(:close!)
     expect(zk).to receive(:create) { "full_path" }
     expect(zk).to receive(:delete).with("full_path", anything())
 


### PR DESCRIPTION
Zookeeper client spawns a reconnect thread that is not killed when zk.close is called, but it is only killed when zk.close! (https://github.com/zk-ruby/zk/blob/master/lib/zk/client/threaded.rb#L332) is called. 

In order to trigger the thread leak, have nerve running with a few services, watch the number of threads for the nerve process, then kill zookeeper instances (wait for 30secs timeout for ZK ping). Then relaunch ZK and watch the thread count. It will grow by 2 per process. 

This fixes the thread leak by joining the reconnect thread when Zookeeper goes down.

