### PR TITLE
Support Netflix Exhibitor

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,10 +16,13 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
+    addressable (2.3.8)
     amq-protocol (1.9.2)
     bunny (1.1.0)
       amq-protocol (>= 1.9.2)
     coderay (1.1.0)
+    crack (0.4.2)
+      safe_yaml (~> 1.0.0)
     diff-lcs (1.2.5)
     etcd (0.2.4)
       mixlib-log
@@ -52,10 +55,15 @@ GEM
     rspec-mocks (3.1.3)
       rspec-support (~> 3.1.0)
     rspec-support (3.1.2)
+    safe_yaml (1.0.4)
     slop (3.6.0)
     thread_safe (0.3.4)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
+    vcr (2.9.3)
+    webmock (1.21.0)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
     zk (1.9.5)
       logging (~> 1.8.2)
       zookeeper (~> 1.4.0)
@@ -70,6 +78,8 @@ DEPENDENCIES
   pry
   rake
   rspec (~> 3.1.0)
+  vcr
+  webmock
 
 BUNDLED WITH
    1.10.5

--- a/lib/nerve/reporter.rb
+++ b/lib/nerve/reporter.rb
@@ -8,7 +8,7 @@ module Nerve
       type = service['reporter_type'] || 'zookeeper'
       reporter = begin
         require "nerve/reporter/#{type.downcase}"
-        self.const_get(type.downcase.capitalize)
+        self.const_get(type.split('_').collect(&:capitalize).join)
       rescue Exception => e
         raise ArgumentError, "specified a reporter_type of #{type}, which could not be found: #{e}"
       end

--- a/lib/nerve/reporter/zookeeper_exhibitor.rb
+++ b/lib/nerve/reporter/zookeeper_exhibitor.rb
@@ -90,7 +90,7 @@ class Nerve::Reporter
         raise "Something went wrong: #{res.body}"
       end
       hosts = JSON.load(res.body)
-      log.info hosts
+      log.debug hosts
       hosts['servers'].map { |s| s.concat(':' + hosts['port'].to_s) }
     end
 

--- a/lib/nerve/reporter/zookeeper_exhibitor.rb
+++ b/lib/nerve/reporter/zookeeper_exhibitor.rb
@@ -30,6 +30,7 @@ class Nerve::Reporter
     end
 
     def poll
+      return unless @watcher.nil?
       @watcher = Thread.new do
         while true do
           new_zk_hosts = fetch_hosts_from_exhibitor
@@ -39,7 +40,6 @@ class Nerve::Reporter
             @zk_connection_string = new_zk_hosts
             start
             report_up
-            break
           end
           sleep @exhibitor_poll_interval
         end

--- a/lib/nerve/reporter/zookeeper_exhibitor.rb
+++ b/lib/nerve/reporter/zookeeper_exhibitor.rb
@@ -8,64 +8,35 @@ require 'zk'
 class Nerve::Reporter
   class ZookeeperExhibitor < Base
     DEFAULT_EXHIBITOR_POLL_INTERVAL = 10
+    @@zk_pool = {}
+    @@zk_pool_count = {}
+    @@zk_pool_lock = Mutex.new
+
     def initialize(service)
-      %w{exhibitor_url zk_path instance_id host port}.each do |required|
+      %w{exhibitor_url zk_path}.each do |required|
         raise ArgumentError, "missing required argument #{required} for new service watcher" unless service[required]
       end
+      # Since we pool we get one connection per zookeeper cluster
       @exhibitor_url = service['exhibitor_url']
       @exhibitor_user = service['exhibitor_user']
       @exhibitor_password = service['exhibitor_password']
       @exhibitor_poll_interval = service['exhibitor_poll_interval'] || DEFAULT_EXHIBITOR_POLL_INTERVAL
-      @zk_hosts = fetch_hosts_from_exhibitor
-      @zk_path = service['zk_path']
-      @path = @zk_hosts.shuffle.join(',') + @zk_path
-      @data = parse_data({'host' => service['host'], 'port' => service['port'], 'name' => service['instance_id']})
+      @zk_connection_string = fetch_hosts_from_exhibitor
+      @data = parse_data(get_service_data(service))
 
-      @key = "/#{service['instance_id']}_"
+      @zk_path = service['zk_path']
+      @key_prefix = @zk_path + "/#{service['instance_id']}_"
       @full_key = nil
     end
-
-    def start
-      log.info "nerve: waiting to connect to zookeeper at #{@path}"
-      @zk = ZK.new(@path)
-      poll
-      log.info "nerve: successfully created zk connection to #{@path}"
-    end
-
-    def stop
-      log.info "nerve: closing zk connection at #{@path}"
-      report_down
-      @zk.close!
-    end
-
-    def report_up
-      zk_save
-    end
-
-    def report_down
-      zk_delete
-    end
-
-    def update_data(new_data='')
-      @data = parse_data(new_data)
-      zk_save
-    end
-
-    def ping?
-      @watcher.alive? && @zk && @zk.connected?
-    end
-
-    private
 
     def poll
       @watcher = Thread.new do
         while true do
           new_zk_hosts = fetch_hosts_from_exhibitor
-          if new_zk_hosts && @zk_hosts != new_zk_hosts
+          if new_zk_hosts && @zk_connection_string != new_zk_hosts
             log.info "nerve: ZooKeeper ensamble changed, going to reconnect"
-            @zk_hosts = new_zk_hosts
-            @path = @zk_hosts.shuffle.join(',') + @zk_path
             stop
+            @zk_connection_string = new_zk_hosts
             start
             report_up
             break
@@ -92,8 +63,64 @@ class Nerve::Reporter
       end
       hosts = JSON.load(res.body)
       log.debug hosts
-      hosts['servers'].map { |s| s.concat(':' + hosts['port'].to_s) }
+      zk_hosts = hosts['servers'].map { |s| s.concat(':' + hosts['port'].to_s) }
+      zk_hosts.sort.join(',')
     end
+
+
+    def start()
+      log.info "nerve: waiting to connect to zookeeper to #{@zk_connection_string}"
+      # Ensure that all Zookeeper reporters re-use a single zookeeper
+      # connection to any given set of zk hosts.
+      @@zk_pool_lock.synchronize {
+        unless @@zk_pool.has_key?(@zk_connection_string)
+          log.info "nerve: creating pooled connection to #{@zk_connection_string}"
+          @@zk_pool[@zk_connection_string] = ZK.new(@zk_connection_string, :timeout => 5)
+          @@zk_pool_count[@zk_connection_string] = 1
+          poll
+          log.info "nerve: successfully created zk connection to #{@zk_connection_string}"
+        else
+          @@zk_pool_count[@zk_connection_string] += 1
+          log.info "nerve: re-using existing zookeeper connection to #{@zk_connection_string}"
+        end
+        @zk = @@zk_pool[@zk_connection_string]
+        log.info "nerve: retrieved zk connection to #{@zk_connection_string}"
+      }
+    end
+
+    def stop()
+      log.info "nerve: removing zk node at #{@full_key}" if @full_key
+      begin
+        report_down
+      ensure
+        @@zk_pool_lock.synchronize {
+          @@zk_pool_count[@zk_connection_string] -= 1
+          # Last thread to use the connection closes it
+          if @@zk_pool_count[@zk_connection_string] == 0
+            log.info "nerve: closing zk connection to #{@zk_connection_string}"
+            begin
+              @zk.close!
+            ensure
+              @@zk_pool.delete(@zk_connection_string)
+            end
+          end
+        }
+      end
+    end
+
+    def report_up()
+      zk_save
+    end
+
+    def report_down
+      zk_delete
+    end
+
+    def ping?
+      return @watcher.alive? && @zk.connected? && @zk.exists?(@full_key || '/')
+    end
+
+    private
 
     def zk_delete
       if @full_key
@@ -103,7 +130,8 @@ class Nerve::Reporter
     end
 
     def zk_create
-      @full_key = @zk.create(@key, :data => @data, :mode => :ephemeral_sequential)
+      @zk.mkdir_p(@zk_path)
+      @full_key = @zk.create(@key_prefix, :data => @data, :mode => :ephemeral_sequential)
     end
 
     def zk_save
@@ -117,3 +145,4 @@ class Nerve::Reporter
     end
   end
 end
+

--- a/lib/nerve/reporter/zookeeper_exhibitor.rb
+++ b/lib/nerve/reporter/zookeeper_exhibitor.rb
@@ -1,0 +1,118 @@
+require 'nerve/reporter/base'
+require 'net/http'
+require 'thread'
+require 'json'
+require 'zk'
+
+
+class Nerve::Reporter
+  class ZookeeperExhibitor < Base
+    DEFAULT_EXHIBITOR_POLL_INTERVAL = 5
+    def initialize(service)
+      %w{exhibitor_url zk_path instance_id host port}.each do |required|
+        raise ArgumentError, "missing required argument #{required} for new service watcher" unless service[required]
+      end
+      @exhibitor_url = service['exhibitor_url']
+      @exhibitor_user = service['exhibitor_user']
+      @exhibitor_password = service['exhibitor_password']
+      @exhibitor_poll_interval = service['exhibitor_poll_interval'] || DEFAULT_EXHIBITOR_POLL_INTERVAL
+      @zk_hosts = fetch_hosts_from_exhibitor
+      @zk_path = service['zk_path']
+      @path = @zk_hosts.shuffle.join(',') + @zk_path
+      @data = parse_data({'host' => service['host'], 'port' => service['port'], 'name' => service['instance_id']})
+
+      @key = "/#{service['instance_id']}_"
+      @full_key = nil
+    end
+
+    def start
+      log.info "nerve: waiting to connect to zookeeper at #{@path}"
+      @zk = ZK.new(@path)
+      poll
+      log.info "nerve: successfully created zk connection to #{@path}"
+    end
+
+    def stop
+      log.info "nerve: closing zk connection at #{@path}"
+      report_down
+      @zk.close!
+    end
+
+    def report_up
+      zk_save
+    end
+
+    def report_down
+      zk_delete
+    end
+
+    def update_data(new_data='')
+      @data = parse_data(new_data)
+      zk_save
+    end
+
+    def ping?
+      @watcher.alive? && @zk && @zk.connected?
+    end
+
+    private
+
+    def poll
+      @watcher = Thread.new do
+        while true do
+          new_zk_hosts = fetch_hosts_from_exhibitor
+          if new_zk_hosts and @zk_hosts != new_zk_hosts
+            log.info "nerve: ZooKeeper ensamble changed, going to reconnect"
+            @zk_hosts = new_zk_hosts
+            @path = @zk_hosts.shuffle.join(',') + @zk_path
+            stop
+            start
+            report_up
+            break
+          end
+          sleep @exhibitor_poll_interval
+        end
+      end
+    end
+
+    def fetch_hosts_from_exhibitor
+      uri = URI(@exhibitor_url)
+      req = Net::HTTP::Get.new(uri)
+      if @exhibitor_user and @exhibitor_password
+        req.basic_auth(@exhibitor_user, @exhibitor_password)
+      end
+      req.add_field('Accept', 'application/json')
+      res = Net::HTTP.start(uri.hostname, uri.port) do |http|
+        http.request(req)
+      end
+
+      if res.code.to_i != 200
+        raise "Something went wrong: #{res.body}"
+      end
+      hosts = JSON.load(res.body)
+      log.info hosts
+      hosts['servers'].map { |s| s.concat(':' + hosts['port'].to_s) }
+    end
+
+    def zk_delete
+      if @full_key
+        @zk.delete(@full_key, :ignore => :no_node)
+        @full_key = nil
+      end
+    end
+
+    def zk_create
+      @full_key = @zk.create(@key, :data => @data, :mode => :ephemeral_sequential)
+    end
+
+    def zk_save
+      return zk_create unless @full_key
+
+      begin
+        @zk.set(@full_key, @data)
+      rescue ZK::Exceptions::NoNode
+        zk_create
+      end
+    end
+  end
+end

--- a/lib/nerve/reporter/zookeeper_exhibitor.rb
+++ b/lib/nerve/reporter/zookeeper_exhibitor.rb
@@ -77,7 +77,7 @@ class Nerve::Reporter
 
     def fetch_hosts_from_exhibitor
       uri = URI(@exhibitor_url)
-      req = Net::HTTP::Get.new(uri)
+      req = Net::HTTP::Get.new(uri.request_uri)
       if @exhibitor_user && @exhibitor_password
         req.basic_auth(@exhibitor_user, @exhibitor_password)
       end

--- a/nerve.gemspec
+++ b/nerve.gemspec
@@ -27,6 +27,8 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency "etcd", "~> 0.2.3"
 
   gem.add_development_dependency "rake"
+  gem.add_development_dependency "vcr"
+  gem.add_development_dependency "webmock"
   gem.add_development_dependency "rspec", "~> 3.1.0"
   gem.add_development_dependency "factory_girl"
   gem.add_development_dependency "pry"

--- a/spec/cassettes/Nerve_Reporter_ZookeeperExhibitor/actually_constructs_an_instance.yml
+++ b/spec/cassettes/Nerve_Reporter_ZookeeperExhibitor/actually_constructs_an_instance.yml
@@ -1,0 +1,35 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:8080/exhibitor/v1/cluster/list
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - '*/*'
+      - application/json
+      User-Agent:
+      - Ruby
+      Host:
+      - localhost:8080
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Server:
+      - Jetty(1.0)
+    body:
+      encoding: UTF-8
+      string: '{"servers":["f53aeace1b62"],"port":2181}'
+    http_version: 
+  recorded_at: Wed, 10 Jun 2015 09:34:53 GMT
+recorded_with: VCR 2.9.3

--- a/spec/cassettes/Nerve_Reporter_ZookeeperExhibitor/deregisters_service_on_exit.yml
+++ b/spec/cassettes/Nerve_Reporter_ZookeeperExhibitor/deregisters_service_on_exit.yml
@@ -1,0 +1,35 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:8080/exhibitor/v1/cluster/list
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - '*/*'
+      - application/json
+      User-Agent:
+      - Ruby
+      Host:
+      - localhost:8080
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Server:
+      - Jetty(1.0)
+    body:
+      encoding: UTF-8
+      string: '{"servers":["f53aeace1b62"],"port":2181}'
+    http_version: 
+  recorded_at: Wed, 10 Jun 2015 09:34:53 GMT
+recorded_with: VCR 2.9.3

--- a/spec/lib/nerve/reporter_zookeeper_exhibitor_spec.rb
+++ b/spec/lib/nerve/reporter_zookeeper_exhibitor_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+require 'nerve/reporter/zookeeper_exhibitor'
+
+describe Nerve::Reporter::ZookeeperExhibitor do
+  let(:subject) { {
+      'exhibitor_url' => 'http://localhost:8080/exhibitor/v1/cluster/list',
+      'zk_path' => 'zk_path',
+      'instance_id' => 'instance_id',
+      'host' => 'host',
+      'port' => 'port'
+    }
+  }
+  it 'actually constructs an instance', :vcr do
+    expect(Nerve::Reporter::ZookeeperExhibitor.new(subject).is_a?(Nerve::Reporter::ZookeeperExhibitor)).to be_truthy
+  end
+
+  it 'deregisters service on exit', :vcr do
+    zk = double("zk")
+    allow(zk).to receive(:close!)
+    expect(zk).to receive(:create) { "full_path" }
+    expect(zk).to receive(:delete).with("full_path", anything())
+
+    allow(ZK).to receive(:new).and_return(zk)
+
+    reporter = Nerve::Reporter::ZookeeperExhibitor.new(subject)
+    reporter.start
+    reporter.report_up
+    reporter.stop
+  end
+end

--- a/spec/lib/nerve/reporter_zookeeper_exhibitor_spec.rb
+++ b/spec/lib/nerve/reporter_zookeeper_exhibitor_spec.rb
@@ -17,6 +17,7 @@ describe Nerve::Reporter::ZookeeperExhibitor do
   it 'deregisters service on exit', :vcr do
     zk = double("zk")
     allow(zk).to receive(:close!)
+    expect(zk).to receive(:mkdir_p) { "zk_path" }
     expect(zk).to receive(:create) { "full_path" }
     expect(zk).to receive(:delete).with("full_path", anything())
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,6 +9,15 @@ require "#{File.dirname(__FILE__)}/../lib/nerve"
 require 'factory_girl'
 FactoryGirl.find_definitions
 
+require 'vcr'
+
+VCR.configure do |c|
+  c.cassette_library_dir     = 'spec/cassettes'
+  c.hook_into                :webmock
+  c.default_cassette_options = { :record => :new_episodes }
+  c.configure_rspec_metadata!
+end
+
 RSpec.configure do |config|
   config.run_all_when_everything_filtered = true
   config.filter_run :focus


### PR DESCRIPTION
This PR will add support for Netflix Exhibitor. It's more or less a copy of the regular zookeeper watcher adding but adds polling of the Exhibitor REST endpoint for zk ensemble changes. If the ensemble changes this watcher will detect that and stop the watcher.

This is great when maintaining zookeeper in the cloud to not have static zookeeper endpoints.
