### PR TITLE
Thread haproxy_server_options through from reporters

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,8 @@ The configuration contains the following options:
 * `reporter_type`: the mechanism used to report up/down information; depending on the reporter you choose, additional parameters may be required. Defaults to `zookeeper`
 * `check_interval`: the frequency with which service checks will be initiated; defaults to `500ms`
 * `checks`: a list of checks that nerve will perform; if all of the pass, the service will be registered; otherwise, it will be un-registered
-* `weight`: a positive integer weight value which can be used to affect the haproxy backend weighting in synapse.
+* `weight` (optional): a positive integer weight value which can be used to affect the haproxy backend weighting in synapse.
+* `haproxy_server_options` (optional): a string containing any special haproxy server options for this service instance. For example if you wanted to set a service instance as a backup.
 
 #### Zookeeper Reporter ####
 

--- a/lib/nerve/reporter/base.rb
+++ b/lib/nerve/reporter/base.rb
@@ -26,14 +26,23 @@ class Nerve::Reporter
       %w{instance_id host port}.each do |required|
         raise ArgumentError, "missing required argument #{required} for new service watcher" unless service[required]
       end
-      d = {'host' => service['host'], 'port' => service['port'], 'name' => service['instance_id']}
-      return d unless service.has_key?('weight')
+      d = {
+        'host' => service['host'],
+        'port' => service['port'],
+        'name' => service['instance_id']
+      }
 
       # Weight is optional, but it should be well formed if supplied
-      if service['weight'].to_i >= 0 and "#{service['weight']}".match /^\d+$/
-        d['weight'] = service['weight'].to_i
-      else
-        raise ArgumentError, "invalid 'weight' argument in service data: #{service.inspect}"
+      if service.has_key?('weight')
+        if service['weight'].to_i >= 0 and "#{service['weight']}".match /^\d+$/
+          d['weight'] = service['weight'].to_i
+        else
+          raise ArgumentError, "invalid 'weight' argument in service data: #{service.inspect}"
+        end
+      end
+
+      if service.has_key?('haproxy_server_options')
+        d['haproxy_server_options'] = service['haproxy_server_options']
       end
       d
     end

--- a/spec/lib/nerve/reporter_spec.rb
+++ b/spec/lib/nerve/reporter_spec.rb
@@ -67,6 +67,13 @@ describe Nerve::Reporter::Test do
     it 'works if the weight is a string' do
       expect(subject.get_service_data({'host' => '127.0.0.1', 'port' => 6666, 'instance_id' => 'foobar', 'weight' => '3'})['weight']).to eql(3)
     end
+
+    it 'correctly passes haproxy_server_options' do
+      expect(subject.get_service_data({
+        'host' => '127.0.0.1', 'port' => 6666, 'instance_id' => 'foobar',
+        'haproxy_server_options' => 'backup'
+      })['haproxy_server_options']).to eql('backup')
+    end
   end
 end
 


### PR DESCRIPTION
This option can be used to enable custom server level options in the
fronting haproxy instances, which allows things like declaring that a
particular node is a backup or should be healthchecked a special way.

Synapse already partially supports this option and it will have full support once https://github.com/airbnb/synapse/pull/144 is merged.