### PR TITLE
3xx status codes should mean success

### DIFF
--- a/lib/nerve/service_watcher/http.rb
+++ b/lib/nerve/service_watcher/http.rb
@@ -36,7 +36,9 @@ module Nerve
         code = response.code.to_i
         body = response.body
 
-        if code >= 200 and code < 300 and (@expect == nil || body.include?(@expect))
+        # Any 2xx or 3xx code should be considered healthy. This is standard
+        # practice in HAProxy, nginx, etc ...
+        if code >= 200 and code < 400 and (@expect == nil || body.include?(@expect))
           log.debug "nerve: check #{@name} got response code #{code} with body \"#{body}\""
           return true
         else


### PR DESCRIPTION
Previously nerve considered 3xx to be failure, which is inconsistent
with most other healthcheck systems (e.g. haproxy or nginx).

Should fix #77