### PR TITLE
Add mysql service connectivity check

### DIFF
--- a/lib/nerve/service_watcher.rb
+++ b/lib/nerve/service_watcher.rb
@@ -1,6 +1,7 @@
 require 'nerve/service_watcher/tcp'
 require 'nerve/service_watcher/http'
 require 'nerve/service_watcher/rabbitmq'
+require 'nerve/service_watcher/mysql'
 
 module Nerve
   class ServiceWatcher

--- a/lib/nerve/service_watcher/mysql.rb
+++ b/lib/nerve/service_watcher/mysql.rb
@@ -1,0 +1,40 @@
+require 'nerve/service_watcher/base'
+
+module Nerve
+  module ServiceCheck
+    class MysqlServiceCheck < BaseServiceCheck
+      require 'mysql2'
+
+      def initialize(opts={})
+        super
+
+        raise ArgumentError, "missing required argument 'user' in mysql check" unless opts['user']
+
+        @user = opts['user']
+        @pass = opts['password'] || ''
+        @host = opts['host'] || '127.0.0.1'
+        @port = opts['port'] || '3306'
+      end
+
+      def check
+        # the idea of health check is similar to haproxy option mysql-check
+        log.debug "nerve: running mysql health check #{@name}"
+
+        begin
+          log.debug "nerve: mysql connect #{@host}:#{@port} as #{@user}"
+          conn = Mysql2::Client.new(:host => @host, :username => @user, :password => @pass, :port => @port)
+        rescue Mysql2::Error => e
+          log.debug "nerve: mysql check error #{e.errno}: #{e.error}"
+          return false
+        ensure
+          conn.close if conn
+        end
+
+        return true
+      end
+    end
+
+    CHECKS ||= {}
+    CHECKS['mysql'] = MysqlServiceCheck
+  end
+end

--- a/nerve.gemspec
+++ b/nerve.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency "zk", "~> 1.9.2"
   gem.add_runtime_dependency "bunny", "= 1.1.0"
   gem.add_runtime_dependency "etcd", "~> 0.2.3"
+  gem.add_runtime_dependency "mysql2", "~> 0.4.2"
 
   gem.add_development_dependency "rake"
   gem.add_development_dependency "rspec", "~> 3.1.0"


### PR DESCRIPTION
The mysql service connectivity check is similar to haproxy option mysql-check, and is used for local
mysql service check. A simple mysql-check uses a user with minimal USAGE privilege and the user may or may not have a password. In our company production, we use haproxy option mysql-check for synapse side service health check, however it does not work with a new db proxy service that we build, and the nerve tcp port health check on the local server is not sufficient. The simple mysql service check borrows the idea of haproxy option mysql-check but it uses mysql client and therefore works with the new proxy. It had been verified in our production test environment.

@igor47 