### PR TITLE
Nerve reports affinity if provided in configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ The configuration contains the following options:
 * `checks`: a list of checks that nerve will perform; if all of the pass, the service will be registered; otherwise, it will be un-registered
 * `weight` (optional): a positive integer weight value which can be used to affect the haproxy backend weighting in synapse.
 * `haproxy_server_options` (optional): a string containing any special haproxy server options for this service instance. For example if you wanted to set a service instance as a backup.
+* `labels` (optional): an object containing user-defined key-value pairs that describe this service instance. For example, you could label service instances with datacenter information.
 
 #### Zookeeper Reporter ####
 

--- a/lib/nerve/reporter/base.rb
+++ b/lib/nerve/reporter/base.rb
@@ -44,6 +44,10 @@ class Nerve::Reporter
       if service.has_key?('haproxy_server_options')
         d['haproxy_server_options'] = service['haproxy_server_options']
       end
+
+      if service.has_key?('labels')
+        d['labels'] = service['labels']
+      end
       d
     end
 

--- a/spec/example_services_spec.rb
+++ b/spec/example_services_spec.rb
@@ -23,6 +23,11 @@ describe "example services are valid" do
       it 'saves the weight data' do
         expect(JSON.parse(Nerve::Reporter.new_from_service(service_data).data)['weight']).to eql(2)
       end
+      it 'saves the labels data' do
+        labels = {'az' => 'us-west-1'}
+        service_data['labels'] = labels
+        expect(JSON.parse(Nerve::Reporter.new_from_service(service_data).data)['labels']).to eq(labels)
+      end
     end
 
     context "when #{item} can be initialized as a valid service watcher" do

--- a/spec/lib/nerve/reporter_spec.rb
+++ b/spec/lib/nerve/reporter_spec.rb
@@ -74,6 +74,13 @@ describe Nerve::Reporter::Test do
         'haproxy_server_options' => 'backup'
       })['haproxy_server_options']).to eql('backup')
     end
+    it 'correctly passes labels' do
+      labels = {'az' => 'us-west-1', 'custom_key' => 'custom_value'}
+      expect(subject.get_service_data({
+        'host' => '127.0.0.1', 'port' => 6666, 'instance_id' => 'foobar',
+        'labels' => labels
+      })['labels']).to eql(labels)
+    end
   end
 end
 


### PR DESCRIPTION
# Haproxy Affinity Configuration in Synapse

Synapse registers service instances and assigns them equal weights in the pool. However in reality the cost of connecting to different instances is not equal: instances could be in different AWS availability zones or be part of different network topologies. There's no existing method for Synapse to support partitioning instances into separate pools based on affinity and to bias load balancing towards the pool with similar affinity.

NOTE: This is different from setting configuration for 'weight' on a per service instance- the weight of a service instance should be computed relative to the value of affinity that Synapse parses from its configuration.

This proposal describes how to add affinity support in Synapse through a new `affinity_options` field in Synapse haproxy configuration. This configuration will define how to map service data (from Nerve or other data sources) to an affinity value and how Synapse will use affinities to distribute traffic between the two pools. This design also requires Nerve to support reporting of additional service data, so users can report affinity values per service instance.

Instead of adding another whitelisted parameter to the service data that is reported, Nerve should support a field `extra_data` that contains a bag of values and is configurable on a per-service basis. Advanced users of Nerve/Synapse can enable reporting of service instance affinity into the `extra_data` bag so that Synapse can parse the information to construct the appropriate HAProxy configuration.

## Example configuration and data payloads

### Nerve service configuration (my_service.json)

Nerve will now accept additional service data under the `extra_data` field.
```
{
     "host": "1.2.3.4",
     "port": 3000,
     "extra_data": {
       "affinity": "us-east-1",
       "custom_tag": "custom_value",
      ...
     }
     ...
}
```

### Nerve zookeeper reporter payload (compact JSON written to ZK)

Nerve reporters will now publish the `extra_data` field in service data.

```json
{"host":"1.2.3.4","port":3000,"name":"i-asdf1234","extra_data":{"affinity":"us-east-1","custom_tag":"custom_value"}}
```

### Synapse configuration (my_service.json)

Synapse supports `affinity_options` in service configuration. Users should provide the affinity for the main server pool, the path to affinity with respect to service instance data and affinity configuration. There would be a "weighted" mode such that when weight is set to 95, 95% of traffic is routed the main pool of similar affinity servers and the remaining 5% routed to the other pool. The "backup" mode would set up the dissimilar affinity pool as HAProxy backup servers.

```
{
  "default_servers": [ ... ],
  "discovery": { ... },
  "haproxy": {
    "server_options": ...,
    "listen": [ ... ],
    "backend": [ ... ],
    "affinity_options": {
      "affinity_path": "/extra_data/affinity",
      "affinity": "us-east-2",
      "mode": "weighted",
      "weight": 95
    }
  }
}
```

### Synapse-generated HAProxy Configuration

(TODO: check if HAProxy supports fractional weights)

Assuming the host has similar affinity to 1.2.3.4, 1.2.3.5 and 1.2.3.6, this would be a possible HAProxy configuration given weight=95:

```
frontend my_service
        bind ::1:3597
        mode tcp
        option tcplog
        bind localhost:3597
        default_backend my_service

backend my_service
        mode tcp
        option tcplog
        server 1.2.3.4:3000_i-foo 1.2.3.4:3000 weight 38
        server 1.2.3.5:3000_i-bar 1.2.3.5:3000 weight 38
        server 1.2.3.6:3000_i-baz 1.2.3.6:3000 weight 38
        server 1.2.4.1:3000_i-zapp 1.2.4.1:3000 weight 3
        server 1.2.4.2:3000_i-brannigan 1.2.4.2:3000 weight 3
```

On a host with similar affinity to only i-zapp, given weight=95:

```
frontend my_service
        bind ::1:3597
        mode tcp
        option tcplog
        bind localhost:3597
        default_backend my_service

backend my_service
        mode tcp
        option tcplog
        server 1.2.3.4:3000_i-foo 1.2.3.4:3000 weight 1
        server 1.2.3.5:3000_i-bar 1.2.3.5:3000 weight 1
        server 1.2.3.6:3000_i-baz 1.2.3.6:3000 weight 1
        server 1.2.4.1:3000_i-zapp 1.2.4.1:3000 weight 76
        server 1.2.4.2:3000_i-brannigan 1.2.4.2:3000 weight 1
```