### PR TITLE
Remove port requirement from nerve

### DIFF
--- a/lib/nerve/service_watcher.rb
+++ b/lib/nerve/service_watcher.rb
@@ -11,7 +11,7 @@ module Nerve
       log.debug "nerve: creating service watcher object"
 
       # check that we have all of the required arguments
-      %w{name instance_id host port}.each do |required|
+      %w{name instance_id host}.each do |required|
         raise ArgumentError, "missing required argument #{required} for new service watcher" unless service[required]
       end
 

--- a/spec/lib/nerve/service_watcher_spec.rb
+++ b/spec/lib/nerve/service_watcher_spec.rb
@@ -10,7 +10,7 @@ describe Nerve::ServiceWatcher do
     end
 
     it 'requires minimum parameters' do
-      %w[name instance_id host port].each do |req|
+      %w[name instance_id host].each do |req|
         service_without = service.dup
         service_without.delete(req)
 


### PR DESCRIPTION
Problem:
Nerve currently requires all services to define a port and fails hard if port is not set. Some "services" (lack of better word) are batch jobs which don't require a port but we'd like to register them through nerve as we would like to build auto deploy and fail over using our service discovery layer.

Solution:
Remove the hard dependancy on port in service watcher.

Debate: 
Should nerve really be responsible for registering non talkative (one which do not latch onto a port) services? At snapdeal we list all our services in yaml files and use https://github.com/yagnik/dendrite to build nerve/synapse config. We'd like to also list any batch jobs in there too. 

@igor47 @jolynch 