### PR TITLE
[nerve] only mkdir_p in zk_create when the path does not exists

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    nerve (0.8.0)
+    nerve (0.8.1)
       bunny (= 1.1.0)
       etcd (~> 0.2.3)
       json

--- a/lib/nerve/reporter/zookeeper.rb
+++ b/lib/nerve/reporter/zookeeper.rb
@@ -83,6 +83,7 @@ class Nerve::Reporter
     end
 
     def zk_create
+      # only mkdir_p if the path does not exist
       @zk.mkdir_p(@zk_path) unless @zk.exists?(@zk_path)
       @full_key = @zk.create(@key_prefix, :data => @data, :mode => :ephemeral_sequential)
     end

--- a/lib/nerve/reporter/zookeeper.rb
+++ b/lib/nerve/reporter/zookeeper.rb
@@ -83,7 +83,7 @@ class Nerve::Reporter
     end
 
     def zk_create
-      @zk.mkdir_p(@zk_path)
+      @zk.mkdir_p(@zk_path) unless @zk.exists?(@zk_path)
       @full_key = @zk.create(@key_prefix, :data => @data, :mode => :ephemeral_sequential)
     end
 

--- a/lib/nerve/version.rb
+++ b/lib/nerve/version.rb
@@ -1,3 +1,3 @@
 module Nerve
-  VERSION = "0.8.0"
+  VERSION = "0.8.1"
 end

--- a/spec/lib/nerve/reporter_zookeeper_spec.rb
+++ b/spec/lib/nerve/reporter_zookeeper_spec.rb
@@ -17,6 +17,7 @@ describe Nerve::Reporter::Zookeeper do
   it 'deregisters service on exit' do
     zk = double("zk")
     allow(zk).to receive(:close!)
+    expect(zk).to receive(:exists?) { "zk_path" }.and_return(false)
     expect(zk).to receive(:mkdir_p) { "zk_path" }
     expect(zk).to receive(:create) { "full_path" }
     expect(zk).to receive(:delete).with("full_path", anything())


### PR DESCRIPTION
to: @jolynch 

The current behavior is always mkdir_p the path before creating childen. This wipes out the config data that we store at the "services" node (as part of the Synapse gem patch). 

This PR adds a check before doing mkdir_p. If the path already exists, it skips mkdir_p.