### PR TITLE
Adding `statsd` dependency and exporting some stats

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,9 @@
 PATH
   remote: .
   specs:
-    nerve (0.8.1)
+    nerve (0.8.2)
       bunny (= 1.1.0)
+      dogstatsd-ruby (~> 3.3.0)
       etcd (~> 0.2.3)
       json
       zk (~> 1.9.2)
@@ -21,20 +22,16 @@ GEM
       amq-protocol (>= 1.9.2)
     coderay (1.1.0)
     diff-lcs (1.2.5)
+    dogstatsd-ruby (3.3.0)
     etcd (0.2.4)
       mixlib-log
     factory_girl (4.5.0)
       activesupport (>= 3.0.0)
     i18n (0.7.0)
-    json (1.8.2)
-    little-plugger (1.1.3)
-    logging (1.8.2)
-      little-plugger (>= 1.1.3)
-      multi_json (>= 1.8.4)
+    json (1.8.3)
     method_source (0.8.2)
     minitest (5.5.1)
-    mixlib-log (1.6.0)
-    multi_json (1.11.2)
+    mixlib-log (1.7.1)
     pry (0.10.1)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
@@ -56,10 +53,9 @@ GEM
     thread_safe (0.3.4)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
-    zk (1.9.5)
-      logging (~> 1.8.2)
+    zk (1.9.6)
       zookeeper (~> 1.4.0)
-    zookeeper (1.4.10)
+    zookeeper (1.4.11)
 
 PLATFORMS
   ruby
@@ -72,4 +68,4 @@ DEPENDENCIES
   rspec (~> 3.1.0)
 
 BUNDLED WITH
-   1.10.5
+   1.16.1

--- a/example/nerve.conf.json
+++ b/example/nerve.conf.json
@@ -1,6 +1,10 @@
 {
   "instance_id": "mymachine",
   "service_conf_dir": "example/nerve_services",
+  "statsd": {
+    "host": "localhost",
+    "port": 8125
+  },
   "services": {
     "your_http_service": {
       "host": "1.2.3.4",

--- a/lib/nerve.rb
+++ b/lib/nerve.rb
@@ -6,6 +6,7 @@ require 'timeout'
 require 'nerve/version'
 require 'nerve/utils'
 require 'nerve/log'
+require 'nerve/statsd'
 require 'nerve/ring_buffer'
 require 'nerve/reporter'
 require 'nerve/service_watcher'
@@ -14,6 +15,7 @@ module Nerve
   class Nerve
     include Logging
     include Utils
+    include StatsD
 
     MAIN_LOOP_SLEEP_S = 10.freeze
     LAUNCH_WAIT_FOR_REPORT_S = 30.freeze
@@ -21,6 +23,9 @@ module Nerve
     def initialize(config_manager)
       log.info 'nerve: setting up!'
       @config_manager = config_manager
+      @config_manager.reload!
+
+      StatsD.configure_statsd(@config_manager.config["statsd"] || {})
 
       # set global variable for exit signal
       $EXIT = false
@@ -45,6 +50,9 @@ module Nerve
       end
 
       log.debug 'nerve: completed init'
+    rescue Exception => e
+      statsd && statsd.increment('nerve.stop', tags: ['stop_avenue:abort', 'stop_location:init'])
+      raise e
     end
 
     def load_config!
@@ -61,107 +69,122 @@ module Nerve
       @instance_id = config['instance_id']
       @watchers_desired = config['services']
       @heartbeat_path = config['heartbeat_path']
+      StatsD.configure_statsd(config["statsd"] || {})
+      statsd.increment('nerve.config.update')
     end
 
     def run
       log.info 'nerve: starting main run loop'
-      begin
-        until $EXIT
-          # Check if configuration needs to be reloaded and reconcile any new
-          # configuration of watchers with old configuration
-          if @config_to_load
-            load_config!
+      statsd.increment('nerve.start')
 
-            # Reap undesired service watchers
-            services_to_reap = @watchers.select{ |name, _|
-              !@watchers_desired.has_key?(name)
-            }.keys()
+      statsd.time('nerve.main_loop.elapsed_time') do
+        begin
+          until $EXIT
+            # Check if configuration needs to be reloaded and reconcile any new
+            # configuration of watchers with old configuration
+            if @config_to_load
+              load_config!
 
-            unless services_to_reap.empty?
-              log.info "nerve: reaping old watchers: #{services_to_reap}"
-              services_to_reap.each do |name|
+              # Reap undesired service watchers
+              services_to_reap = @watchers.select{ |name, _|
+                !@watchers_desired.has_key?(name)
+              }.keys()
+
+              unless services_to_reap.empty?
+                log.info "nerve: reaping old watchers: #{services_to_reap}"
+                services_to_reap.each do |name|
+                  statsd.increment('nerve.watcher.reap', tags: ['reap_reason:old', "watcher_name:#{name}"])
                   reap_watcher(name)
+                end
+              end
+
+              # Start new desired service watchers
+              services_to_launch = @watchers_desired.select{ |name, _|
+                !@watchers.has_key?(name)
+              }.keys()
+
+              unless services_to_launch.empty?
+                log.info "nerve: launching new watchers: #{services_to_launch}"
+                services_to_launch.each do |name|
+                  statsd.increment('nerve.watcher.launch', tags: ['launch_reason:new', "watcher_name:#{name}"])
+                  launch_watcher(name, @watchers_desired[name])
+                end
+              end
+
+              # Detect and update existing service watchers which are in both
+              # the currently running state and the desired (config) watcher
+              # state but have different configurations
+              services_to_update = @watchers.select { |name, _|
+                @watchers_desired.has_key?(name) &&
+                merged_config(@watchers_desired[name], name).hash != @watcher_versions[name]
+              }.keys()
+
+              services_to_update.each do |name|
+                log.info "nerve: detected new config for #{name}"
+                # Keep the old watcher running until the replacement is launched
+                # This keeps the service registered while we change it over
+                # This also keeps connection pools active across diffs
+                temp_name = "#{name}_#{@watcher_versions[name]}"
+                @watchers[temp_name] = @watchers.delete(name)
+                @watcher_versions[temp_name] = @watcher_versions.delete(name)
+                log.info "nerve: launching new watcher for #{name}"
+                statsd.increment('nerve.watcher.launch', tags: ['launch_reason:update', "watcher_name:#{name}"])
+                launch_watcher(name, @watchers_desired[name], :wait => true)
+                log.info "nerve: reaping old watcher #{temp_name}"
+                statsd.increment('nerve.watcher.reap', tags: ['reap_reason:update', "watcher_name:#{temp_name}"])
+                reap_watcher(temp_name)
               end
             end
 
-            # Start new desired service watchers
-            services_to_launch = @watchers_desired.select{ |name, _|
-              !@watchers.has_key?(name)
-            }.keys()
+            # If this was a configuration check, bail out now
+            if @config_manager.options[:check_config]
+              log.info 'nerve: configuration check succeeded, exiting immediately'
+              break
+            end
 
-            unless services_to_launch.empty?
-              log.info "nerve: launching new watchers: #{services_to_launch}"
-              services_to_launch.each do |name|
-                launch_watcher(name, @watchers_desired[name])
+            # Check that watchers are still alive, auto-remediate if they
+            # are not. Sometimes zookeeper flakes out or connections are lost to
+            # remote datacenter zookeeper clusters, failing is not an option
+            relaunch = []
+            @watchers.each do |name, watcher|
+              unless watcher.alive?
+                relaunch << name
               end
             end
 
-            # Detect and update existing service watchers which are in both
-            # the currently running state and the desired (config) watcher
-            # state but have different configurations
-            services_to_update = @watchers.select { |name, _|
-              @watchers_desired.has_key?(name) &&
-              merged_config(@watchers_desired[name], name).hash != @watcher_versions[name]
-            }.keys()
-
-            services_to_update.each do |name|
-              log.info "nerve: detected new config for #{name}"
-              # Keep the old watcher running until the replacement is launched
-              # This keeps the service registered while we change it over
-              # This also keeps connection pools active across diffs
-              temp_name = "#{name}_#{@watcher_versions[name]}"
-              @watchers[temp_name] = @watchers.delete(name)
-              @watcher_versions[temp_name] = @watcher_versions.delete(name)
-              log.info "nerve: launching new watcher for #{name}"
-              launch_watcher(name, @watchers_desired[name], :wait => true)
-              log.info "nerve: reaping old watcher #{temp_name}"
-              reap_watcher(temp_name)
+            relaunch.each do |name|
+              begin
+                log.warn "nerve: watcher #{name} not alive; reaping and relaunching"
+                statsd.increment('nerve.watcher.reap', tags: ['reap_reason:relaunch', 'reap_result:success', "watcher_name:#{name}"])
+                reap_watcher(name)
+              rescue => e
+                log.warn "nerve: could not reap #{name}, got #{e.inspect}"
+                statsd.increment('nerve.watcher.reap', tags: ['reap_reason:relaunch', 'reap_result:fail', "watcher_name:#{name}"])
+              end
+              statsd.increment('nerve.watcher.launch', tags: ['launch_reason:relaunch', "watcher_name:#{name}"])
+              launch_watcher(name, @watchers_desired[name])
             end
+
+            # Indicate we've made progress
+            heartbeat()
+
+            responsive_sleep(MAIN_LOOP_SLEEP_S) { @config_to_load || $EXIT }
           end
-
-          # If this was a configuration check, bail out now
-          if @config_manager.options[:check_config]
-            log.info 'nerve: configuration check succeeded, exiting immediately'
-            break
+        rescue => e
+          log.error "nerve: encountered unexpected exception #{e.inspect} in main thread"
+          statsd.increment('nerve.stop', tags: ['stop_avenue:abort', 'stop_location:main_loop'])
+          raise e
+        ensure
+          $EXIT = true
+          log.warn 'nerve: reaping all watchers'
+          @watchers.each do |name, _|
+            reap_watcher(name)
           end
-
-          # Check that watchers are still alive, auto-remediate if they
-          # are not. Sometimes zookeeper flakes out or connections are lost to
-          # remote datacenter zookeeper clusters, failing is not an option
-          relaunch = []
-          @watchers.each do |name, watcher|
-            unless watcher.alive?
-              relaunch << name
-            end
-          end
-
-          relaunch.each do |name|
-            begin
-              log.warn "nerve: watcher #{name} not alive; reaping and relaunching"
-              reap_watcher(name)
-            rescue => e
-              log.warn "nerve: could not reap #{name}, got #{e.inspect}"
-            end
-            launch_watcher(name, @watchers_desired[name])
-          end
-
-          # Indicate we've made progress
-          heartbeat()
-
-          responsive_sleep(MAIN_LOOP_SLEEP_S) { @config_to_load || $EXIT }
-        end
-      rescue => e
-        log.error "nerve: encountered unexpected exception #{e.inspect} in main thread"
-        raise e
-      ensure
-        $EXIT = true
-        log.warn 'nerve: reaping all watchers'
-        @watchers.each do |name, _|
-          reap_watcher(name)
         end
       end
 
       log.info 'nerve: exiting'
+      statsd.increment('nerve.stop', tags: ['stop_avenue:clean', 'stop_location:main_loop'])
     ensure
       $EXIT = true
     end

--- a/lib/nerve/reporter/base.rb
+++ b/lib/nerve/reporter/base.rb
@@ -3,6 +3,7 @@ class Nerve::Reporter
   class Base
     include Nerve::Utils
     include Nerve::Logging
+    include Nerve::StatsD
 
     def initialize(opts)
     end

--- a/lib/nerve/service_watcher/base.rb
+++ b/lib/nerve/service_watcher/base.rb
@@ -6,6 +6,8 @@ module Nerve
       include Utils
       include Logging
 
+      attr_reader :name
+
       def initialize(opts={})
         @timeout = opts['timeout'] ? opts['timeout'].to_f : 0.1
         @rise    = opts['rise']    ? opts['rise'].to_i    : 1

--- a/lib/nerve/statsd.rb
+++ b/lib/nerve/statsd.rb
@@ -1,0 +1,32 @@
+require 'datadog/statsd'
+require 'nerve/log'
+
+module Nerve
+  module StatsD
+    def statsd
+      @@STATSD = StatsD.statsd_for(self.class.name) unless !@@STATSD_RELOAD && @@STATSD
+      @@STATSD_RELOAD = false
+      @@STATSD
+    end
+
+    class << self
+      include Logging
+
+      @@STATSD_HOST = "localhost"
+      @@STATSD_PORT = 8125
+      @@STATSD_RELOAD = true
+
+      def statsd_for(classname)
+        log.debug "nerve: creating statsd client for class '#{classname}' on host '#{@@STATSD_HOST}' port #{@@STATSD_PORT}"
+        Datadog::Statsd.new(@@STATSD_HOST, @@STATSD_PORT)
+      end
+
+      def configure_statsd(opts)
+        @@STATSD_HOST = opts['host'] || @@STATSD_HOST
+        @@STATSD_PORT = (opts['port'] || @@STATSD_PORT).to_i
+        @@STATSD_RELOAD = true
+        log.info "nerve: configuring statsd on host '#{@@STATSD_HOST}' port #{@@STATSD_PORT}"
+      end
+    end
+  end
+end

--- a/lib/nerve/version.rb
+++ b/lib/nerve/version.rb
@@ -1,3 +1,3 @@
 module Nerve
-  VERSION = "0.8.1"
+  VERSION = "0.8.2"
 end

--- a/nerve.gemspec
+++ b/nerve.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency "zk", "~> 1.9.2"
   gem.add_runtime_dependency "bunny", "= 1.1.0"
   gem.add_runtime_dependency "etcd", "~> 0.2.3"
+  gem.add_runtime_dependency "dogstatsd-ruby", "~> 3.3.0"
 
   gem.add_development_dependency "rake"
   gem.add_development_dependency "rspec", "~> 3.1.0"


### PR DESCRIPTION
Adding support for exporting metrics through `statsd`.
Also, exporting basic metrics about `nerve`'s health and performance.

How it was tested:
unit tests + manual run and checking exported metrics

Reviewer: @lap1817 

cc @darnaut 