### PR TITLE
[Nerve] avoid zk reporter/watcher reaping on network disconnection (cont.)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    nerve (0.8.2)
+    nerve (0.8.3)
       bunny (= 1.1.0)
       dogstatsd-ruby (~> 3.3.0)
       etcd (~> 0.2.3)

--- a/example/nerve.conf.json
+++ b/example/nerve.conf.json
@@ -1,6 +1,7 @@
 {
   "instance_id": "mymachine",
   "service_conf_dir": "example/nerve_services",
+  "max_repeated_report_failures": 10,
   "statsd": {
     "host": "localhost",
     "port": 8125

--- a/lib/nerve.rb
+++ b/lib/nerve.rb
@@ -68,6 +68,7 @@ module Nerve
       end
       @instance_id = config['instance_id']
       @watchers_desired = config['services']
+      @max_repeated_report_failures = config['max_repeated_report_failures']
       @heartbeat_path = config['heartbeat_path']
       StatsD.configure_statsd(config["statsd"] || {})
       statsd.increment('nerve.config.update')
@@ -199,7 +200,13 @@ module Nerve
     def merged_config(config, name)
       # Get a deep copy so sub-hashes are properly handled
       deep_copy = Marshal.load(Marshal.dump(config))
-      return deep_copy.merge({'instance_id' => @instance_id, 'name' => name})
+      return deep_copy.merge(
+        {
+          'instance_id' => @instance_id,
+          'name' => name,
+          'max_repeated_report_failures' => @max_repeated_report_failures,
+        }
+      )
     end
 
     def launch_watcher(name, config, opts = {})

--- a/lib/nerve/reporter/etcd.rb
+++ b/lib/nerve/reporter/etcd.rb
@@ -28,10 +28,14 @@ class Nerve::Reporter
 
     def report_up()
       etcd_save
+      # assume report up is successful if no error
+      return true
     end
 
     def report_down
       etcd_delete
+      # assume report down is successful if no error
+      return true
     end
 
     def ping?

--- a/lib/nerve/service_watcher.rb
+++ b/lib/nerve/service_watcher.rb
@@ -65,6 +65,8 @@ module Nerve
       @run_thread = nil
       @should_finish = false
 
+      @max_repeated_report_failures = service['max_repeated_report_failures'] || 10
+
       log.debug "nerve: created service watcher for #{@name} with #{@service_checks.size} checks"
     end
 
@@ -97,10 +99,18 @@ module Nerve
     def run()
       log.info "nerve: starting service watch #{@name}"
       statsd.increment('nerve.watcher.start', tags: ["service_name:#{@name}"])
+
       @reporter.start()
 
-      until watcher_should_exit?
-        check_and_report
+      repeated_report_failures = 0
+      until watcher_should_exit? || repeated_report_failures >= @max_repeated_report_failures
+        report_succeeded = check_and_report
+
+        if report_succeeded
+          repeated_report_failures = 0
+        else
+          repeated_report_failures += 1
+        end
 
         # wait to run more checks but make sure to exit if $EXIT
         # we avoid sleeping for the entire check interval at once
@@ -108,7 +118,11 @@ module Nerve
         responsive_sleep (@check_interval) { watcher_should_exit? }
       end
 
-      statsd.increment('nerve.watcher.stop', tags: ['stop_avenue:clean', 'stop_location:main_loop', "service_name:#{@name}"])
+      if repeated_report_failures >= @max_repeated_report_failures
+        statsd.increment('nerve.watcher.stop', tags: ['stop_avenue:failure', 'stop_location:main_loop', "service_name:#{@name}"])
+      else
+        statsd.increment('nerve.watcher.stop', tags: ['stop_avenue:clean', 'stop_location:main_loop', "service_name:#{@name}"])
+      end
     rescue StandardError => e
       statsd.increment('nerve.watcher.stop', tags: ['stop_avenue:abort', 'stop_location:main_loop', "service_name:#{@name}"])
       log.error "nerve: error in service watcher #{@name}: #{e.inspect}"
@@ -131,17 +145,34 @@ module Nerve
       is_up = check?
       log.debug "nerve: current service status for #{@name} is #{is_up.inspect}"
 
+      report_succeeded = true
       if is_up != @was_up
-        statsd.increment('nerve.watcher.status.transition', tags: ["new_status:#{is_up ? "up" : "down"}", "service_name:#{@name}"])
         if is_up
-          @reporter.report_up
-          log.info "nerve: service #{@name} is now up"
+          report_succeeded = @reporter.report_up
+          if report_succeeded
+            log.info "nerve: service #{@name} is now up"
+          else
+            log.warn "nerve: service #{@name} failed to report up"
+          end
         else
-          @reporter.report_down
-          log.warn "nerve: service #{@name} is now down"
+          report_succeeded = @reporter.report_down
+          if report_succeeded
+            log.warn "nerve: service #{@name} is now down"
+          else
+            log.warn "nerve: service #{@name} failed to report down"
+          end
         end
         @was_up = is_up
+
+        if report_succeeded
+          statsd.increment('nerve.watcher.status.transition', tags: ["new_status:#{is_up ? "up" : "down"}", "service_name:#{@name}"])
+          statsd.increment('nerve.watcher.status.report.count', tags: ["report_result:success", "service_name:#{@name}"])
+        else
+          statsd.increment('nerve.watcher.status.report.count', tags: ["report_result:fail", "service_name:#{@name}"])
+        end
       end
+
+      return report_succeeded
     end
 
     def check?

--- a/lib/nerve/version.rb
+++ b/lib/nerve/version.rb
@@ -1,3 +1,3 @@
 module Nerve
-  VERSION = "0.8.2"
+  VERSION = "0.8.3"
 end

--- a/spec/lib/nerve/reporter_zookeeper_spec.rb
+++ b/spec/lib/nerve/reporter_zookeeper_spec.rb
@@ -90,41 +90,47 @@ describe Nerve::Reporter::Zookeeper do
     end
 
     context "when there is a short disconnection" do
-      before(:each) do
+      it 'returns false on ping?' do
         # this condition is triggered if connection is shortly interrupted
         # so connected? still return true
         expect(zk).to receive(:exists?).and_raise(ZK::Exceptions::OperationTimeOut)
-      end
-
-      it 'returns false on ping?' do
         expect(@reporter.ping?).to be false
       end
 
       it 'swallows zk connetion errors and returns false on report_up' do
+        # this condition is triggered if connection is shortly interrupted
+        # so connected? still return true
+        expect(zk).to receive(:set).and_raise(ZK::Exceptions::OperationTimeOut)
         expect(@reporter.report_up).to be false
       end
 
       it 'swallows zk connetion errors and returns false on report_down' do
+        # this condition is triggered if connection is shortly interrupted
+        # so connected? still return true
+        expect(zk).to receive(:delete).and_raise(ZK::Exceptions::OperationTimeOut)
         expect(@reporter.report_down).to be false
       end
     end
 
     context "when there is other ZK errors" do
-      before(:each) do
+      it 'raises zk non-connection error on ping?' do
         # this condition is triggered if connection is shortly interrupted
         # so connected? still return true
         expect(zk).to receive(:exists?).and_raise(ZK::Exceptions::SessionExpired)
-      end
-
-      it 'raises zk non-connection error on ping?' do
         expect {@reporter.ping?}.to raise_error(ZK::Exceptions::SessionExpired)
       end
 
       it 'raises zk non-connetion errors on report_up' do
+        # this condition is triggered if connection is shortly interrupted
+        # so connected? still return true
+        expect(zk).to receive(:set).and_raise(ZK::Exceptions::SessionExpired)
         expect {@reporter.report_up}.to raise_error(ZK::Exceptions::SessionExpired)
       end
 
       it 'raises zk non-connetion errors on report_down' do
+        # this condition is triggered if connection is shortly interrupted
+        # so connected? still return true
+        expect(zk).to receive(:delete).and_raise(ZK::Exceptions::SessionExpired)
         expect {@reporter.report_down}.to raise_error(ZK::Exceptions::SessionExpired)
       end
     end

--- a/spec/lib/nerve/reporter_zookeeper_spec.rb
+++ b/spec/lib/nerve/reporter_zookeeper_spec.rb
@@ -10,13 +10,16 @@ describe Nerve::Reporter::Zookeeper do
       'port' => 'port'
     }
   }
+
+  let(:zk) { double("zk") }
+
   it 'actually constructs an instance' do
     expect(Nerve::Reporter::Zookeeper.new(subject).is_a?(Nerve::Reporter::Zookeeper)).to eql(true)
   end
 
   it 'deregisters service on exit' do
-    zk = double("zk")
     allow(zk).to receive(:close!)
+    allow(zk).to receive(:connected?).and_return(true)
     expect(zk).to receive(:exists?) { "zk_path" }.and_return(false)
     expect(zk).to receive(:mkdir_p) { "zk_path" }
     expect(zk).to receive(:create) { "full_path" }
@@ -28,6 +31,103 @@ describe Nerve::Reporter::Zookeeper do
     reporter.start
     reporter.report_up
     reporter.stop
+  end
+
+  context "when reporter is up" do
+    before(:each) do
+      allow(zk).to receive(:close!)
+      allow(zk).to receive(:connected?).and_return(true)
+      allow(zk).to receive(:exists?) { "zk_path" }.and_return(false)
+      allow(zk).to receive(:mkdir_p) { "zk_path" }
+      allow(zk).to receive(:create) { "full_path" }
+      allow(zk).to receive(:set) { "full_path" }
+      allow(zk).to receive(:delete).with("full_path", anything())
+      allow(ZK).to receive(:new).and_return(zk)
+      @reporter = Nerve::Reporter::Zookeeper.new(subject)
+      @reporter.start
+      @reporter.report_up
+    end
+
+    after(:each) do
+      # reset the class variable to avoid mock object zk leak
+      Nerve::Reporter::Zookeeper.class_variable_set(:@@zk_pool, {})
+      Nerve::Reporter::Zookeeper.class_variable_set(:@@zk_pool_count, {})
+    end
+
+    it "returns true on report_up" do
+      expect(@reporter.report_up).to be true
+    end
+
+    it "returns true on report_down" do
+      expect(@reporter.report_down).to be true
+    end
+
+    it "returns true on ping?" do
+      expect(zk).to receive(:exists?) { "zk_path" }.and_return(true)
+      expect(@reporter.ping?).to be true
+    end
+
+    context "when zk.connected? started to return false" do
+      before(:each) do
+        # this condition is triggered if connection has been lost for a while (a few sec)
+        expect(zk).to receive(:connected?).and_return(false)
+      end
+
+      it 'returns false on ping?' do
+        expect(zk).not_to receive(:exists?)
+        expect(@reporter.ping?).to be false
+      end
+
+      it 'returns false on report_up without zk operation' do
+        expect(zk).not_to receive(:set)
+        expect(@reporter.report_up).to be false
+      end
+
+      it 'returns false on report_up without zk operation' do
+        expect(zk).not_to receive(:delete)
+        expect(@reporter.report_down).to be false
+      end
+    end
+
+    context "when there is a short disconnection" do
+      before(:each) do
+        # this condition is triggered if connection is shortly interrupted
+        # so connected? still return true
+        expect(zk).to receive(:exists?).and_raise(ZK::Exceptions::OperationTimeOut)
+      end
+
+      it 'returns false on ping?' do
+        expect(@reporter.ping?).to be false
+      end
+
+      it 'swallows zk connetion errors and returns false on report_up' do
+        expect(@reporter.report_up).to be false
+      end
+
+      it 'swallows zk connetion errors and returns false on report_down' do
+        expect(@reporter.report_down).to be false
+      end
+    end
+
+    context "when there is other ZK errors" do
+      before(:each) do
+        # this condition is triggered if connection is shortly interrupted
+        # so connected? still return true
+        expect(zk).to receive(:exists?).and_raise(ZK::Exceptions::SessionExpired)
+      end
+
+      it 'raises zk non-connection error on ping?' do
+        expect {@reporter.ping?}.to raise_error(ZK::Exceptions::SessionExpired)
+      end
+
+      it 'raises zk non-connetion errors on report_up' do
+        expect {@reporter.report_up}.to raise_error(ZK::Exceptions::SessionExpired)
+      end
+
+      it 'raises zk non-connetion errors on report_down' do
+        expect {@reporter.report_down}.to raise_error(ZK::Exceptions::SessionExpired)
+      end
+    end
   end
 end
 


### PR DESCRIPTION
This PR is to follow the similar idea in the PR on Synapse (https://github.com/airbnb/synapse/pull/250).

The current logic in Nerve is that: if an error is raised from the reporter (e.g. zookeeper reporter) when ping?, report_up, report_down, the watcher thread will stop the reporter (so it tries to remove the znode). Then the Nerve main thread will reap the watcher and relaunch it.

This caused unnecessary Nerve status flipping while in short network disconnection. The ping? function on reporter is most frequently called by the watcher thread. E.g., 
  - when a disconnection happens while the the reporter is ping, it raises an exception
  - the reporter then tries to remove the znode which succeeded as the disconnection was short.
  - after the watcher is relaunched, the znode is added again

Flipping nerve status triggers more Synapse read, which make the network saturation more likely to happen.

### Changes
 - reporter.ping?, report_up, report_down will catch ZK connection exceptions.
 - reporter.report_up, reporter.report_down will return a bool value. 
 -- if everything goes good, they return true
 -- if zk connection exception was captured, return false
 -- other exceptions, raise it
 - service watcher now has a a circuit break. a counter keeps tracking repeated check_report failures (as returned by reporter). if that goes beyond a threshold, the run() thread will end.  

### Test
Rspec added/updated
Tested on mango-test with simulated packet loss

Reviewers: 
@igor47  @jolynch @juchem @ken-experiment