### PR TITLE
Show how to run the executable

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,13 @@ permissions. You can also install via bundler, but keep in mind you'll pick up
 Nerve's version of library dependencies and possibly not the ones you need
 for your infra/apps.
 
+You can now run the nerve binary like:
+
+```bash
+export GEM_PATH=/opt/smartstack/nerve
+/opt/smartstack/nerve/bin/nerve --help
+```
+
 ## Configuration ##
 
 Nerve depends on a single configuration file, in json format.


### PR DESCRIPTION
I had some problems running nerve due to a missing GEM_PATH (I'm not a Ruby guy). I resolved it after finding the instructions on how to run Synapse.

This change adds similar running instructions borrowed from the Synapse readme.