### PR TITLE
upgrade activesupport to 4.2.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     nerve (0.8.4)
+      activesupport (~> 4.2, >= 4.2.2)
       bunny (= 1.1.0)
       dogstatsd-ruby (~> 3.3.0)
       etcd (~> 0.2.3)
@@ -12,32 +13,32 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (4.2.0)
+    activesupport (4.2.10)
       i18n (~> 0.7)
-      json (~> 1.7, >= 1.7.7)
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
-    amq-protocol (1.9.2)
+    amq-protocol (2.3.0)
     bunny (1.1.0)
       amq-protocol (>= 1.9.2)
-    coderay (1.1.0)
-    diff-lcs (1.2.5)
+    coderay (1.1.2)
+    concurrent-ruby (1.0.5)
+    diff-lcs (1.3)
     dogstatsd-ruby (3.3.0)
     etcd (0.2.4)
       mixlib-log
-    factory_girl (4.5.0)
+    factory_girl (4.9.0)
       activesupport (>= 3.0.0)
-    i18n (0.7.0)
-    json (1.8.3)
-    method_source (0.8.2)
-    minitest (5.5.1)
-    mixlib-log (1.7.1)
-    pry (0.10.1)
+    i18n (0.9.5)
+      concurrent-ruby (~> 1.0)
+    json (2.1.0)
+    method_source (0.9.0)
+    minitest (5.11.3)
+    mixlib-log (2.0.4)
+    pry (0.11.3)
       coderay (~> 1.1.0)
-      method_source (~> 0.8.1)
-      slop (~> 3.4)
-    rake (10.1.1)
+      method_source (~> 0.9.0)
+    rake (12.3.1)
     redis (3.3.5)
     rspec (3.1.0)
       rspec-core (~> 3.1.0)
@@ -51,9 +52,8 @@ GEM
     rspec-mocks (3.1.3)
       rspec-support (~> 3.1.0)
     rspec-support (3.1.2)
-    slop (3.6.0)
-    thread_safe (0.3.4)
-    tzinfo (1.2.2)
+    thread_safe (0.3.6)
+    tzinfo (1.2.5)
       thread_safe (~> 0.1)
     zk (1.9.6)
       zookeeper (~> 1.4.0)
@@ -70,4 +70,4 @@ DEPENDENCIES
   rspec (~> 3.1.0)
 
 BUNDLED WITH
-   1.16.1
+   1.16.2

--- a/nerve.gemspec
+++ b/nerve.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency "redis", "= 3.3.5"
   gem.add_runtime_dependency "etcd", "~> 0.2.3"
   gem.add_runtime_dependency "dogstatsd-ruby", "~> 3.3.0"
+  gem.add_runtime_dependency "activesupport", '~> 4.2', ">= 4.2.2"
 
   gem.add_development_dependency "rake"
   gem.add_development_dependency "rspec", "~> 3.1.0"


### PR DESCRIPTION
[internal ticket: TR-703]

Upgrade activesupport to 4.2.0

The original test suite passes.

From the Gemfile.lock, seems the activesupport is only used for running tests