### PR TITLE
Add no-op service check

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    nerve (0.8.6)
+    nerve (0.8.7)
       bunny (= 1.1.0)
       dogstatsd-ruby (~> 3.3.0)
       etcd (~> 0.2.3)

--- a/lib/nerve/service_watcher.rb
+++ b/lib/nerve/service_watcher.rb
@@ -1,5 +1,6 @@
 require 'nerve/service_watcher/tcp'
 require 'nerve/service_watcher/http'
+require 'nerve/service_watcher/noop'
 require 'nerve/service_watcher/rabbitmq'
 require 'nerve/service_watcher/redis'
 

--- a/lib/nerve/service_watcher/noop.rb
+++ b/lib/nerve/service_watcher/noop.rb
@@ -1,0 +1,17 @@
+require 'nerve/service_watcher/base'
+
+module Nerve
+  module ServiceCheck
+    # ServiceCheck that checks nothing, but returns true.  Useful in scenarios
+    # where you want the mere fact of nerve running to mean your node is
+    # registered.
+    class NoopServiceCheck < BaseServiceCheck
+      def check
+        true
+      end
+    end
+
+    CHECKS ||= {}
+    CHECKS['noop'] = NoopServiceCheck
+  end
+end

--- a/lib/nerve/version.rb
+++ b/lib/nerve/version.rb
@@ -1,3 +1,3 @@
 module Nerve
-  VERSION = "0.8.6"
+  VERSION = "0.8.7"
 end

--- a/spec/lib/nerve/service_watcher/noop_spec.rb
+++ b/spec/lib/nerve/service_watcher/noop_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+require 'nerve/service_watcher/noop'
+
+describe Nerve::ServiceCheck::NoopServiceCheck do
+  let(:check) {
+    {
+      'type' => 'noop',
+    }
+  }
+
+
+  describe 'check' do
+    let(:service_check) { described_class.new(check) }
+
+    it 'is always true' do
+      expect(service_check.check).to eq(true)
+    end
+  end
+end
+


### PR DESCRIPTION
For when you just want to will something in to health.

This check can be used when the presence of a running nerve process on a
node is a reasonable enough proxy for likely health of the service the
node is meant to be running.  In our case, we're using nerve zk
registration to expose some services over DNS, and we have a service
that needs to have exposed DNS names _before_ the service can properly
start.  It is a special case where it's better to maintain the
registration than to accurately account for health.

Having a very simple no-op health check seems like a reasonable check to add.