### PR TITLE
Gracefully handle Zookeeper::Exceptions::NotConnected

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    nerve (0.8.7)
+    nerve (0.8.8)
       bunny (= 1.1.0)
       dogstatsd-ruby (~> 3.3.0)
       etcd (~> 0.2.3)

--- a/lib/nerve/reporter/zookeeper.rb
+++ b/lib/nerve/reporter/zookeeper.rb
@@ -1,11 +1,11 @@
 require 'nerve/reporter/base'
 require 'thread'
 require 'zk'
-
+require 'zookeeper'
 
 class Nerve::Reporter
   class Zookeeper < Base
-    ZK_CONNECTION_ERRORS = [ZK::Exceptions::OperationTimeOut, ZK::Exceptions::ConnectionLoss]
+    ZK_CONNECTION_ERRORS = [ZK::Exceptions::OperationTimeOut, ZK::Exceptions::ConnectionLoss, ::Zookeeper::Exceptions::NotConnected]
 
     @@zk_pool = {}
     @@zk_pool_count = {}

--- a/lib/nerve/version.rb
+++ b/lib/nerve/version.rb
@@ -1,3 +1,3 @@
 module Nerve
-  VERSION = "0.8.7"
+  VERSION = "0.8.8"
 end

--- a/spec/lib/nerve/reporter_zookeeper_spec.rb
+++ b/spec/lib/nerve/reporter_zookeeper_spec.rb
@@ -112,14 +112,14 @@ describe Nerve::Reporter::Zookeeper do
         expect(@reporter.report_down).to be false
       end
 
-      it 'swallows zk connetion errors and returns false on report_up' do
+      it 'swallows zookeeper not connected errors and returns false on report_up' do
         # this condition is triggered if connection is shortly interrupted
         # so connected? still return true
         expect(zk).to receive(:set).and_raise(::Zookeeper::Exceptions::NotConnected)
         expect(@reporter.report_up).to be false
       end
 
-      it 'swallows zk not connected errors and returns false on report_down' do
+      it 'swallows zookeeper not connected errors and returns false on report_down' do
         # this condition is triggered if connection is shortly interrupted
         # so connected? still return true
         expect(zk).to receive(:delete).and_raise(::Zookeeper::Exceptions::NotConnected)

--- a/spec/lib/nerve/reporter_zookeeper_spec.rb
+++ b/spec/lib/nerve/reporter_zookeeper_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 require 'nerve/reporter/zookeeper'
+require 'zookeeper'
 
 describe Nerve::Reporter::Zookeeper do
   let(:subject) { {
@@ -110,6 +111,21 @@ describe Nerve::Reporter::Zookeeper do
         expect(zk).to receive(:delete).and_raise(ZK::Exceptions::OperationTimeOut)
         expect(@reporter.report_down).to be false
       end
+
+      it 'swallows zk connetion errors and returns false on report_up' do
+        # this condition is triggered if connection is shortly interrupted
+        # so connected? still return true
+        expect(zk).to receive(:set).and_raise(::Zookeeper::Exceptions::NotConnected)
+        expect(@reporter.report_up).to be false
+      end
+
+      it 'swallows zk not connected errors and returns false on report_down' do
+        # this condition is triggered if connection is shortly interrupted
+        # so connected? still return true
+        expect(zk).to receive(:delete).and_raise(::Zookeeper::Exceptions::NotConnected)
+        expect(@reporter.report_down).to be false
+      end
+
     end
 
     context "when there is other ZK errors" do


### PR DESCRIPTION
## Issue
When load / network saturation causes zookeeper connection issues, nerve becomes flapping: even though service watcher is always healthy, nerve service reporter keeps reporting up over and over again, putting more load on zookeeper and making things worse

The symptom is very similar to what was reported before: https://github.com/airbnb/nerve/issues/92

## Root Cause
[zk-ruby/zk](https://github.com/zk-ruby/zk) as a high level wrapper doesn't wrap all the exceptions from the low-level binding [zk-ruby/zookeeper](https://github.com/zk-ruby/zookeeper), for example, Zookeeper::Exceptions::NotConnected

Looking at the [documentation](https://www.rubydoc.info/gems/zk/ZK/Exceptions), it doesn't mentioned that native exception could be thrown by high level wrapper either.

Therefore the current implementation does NOT handle native error Zookeeper::Exceptions::NotConnected at all, which is supposed be handled like high level errors, for example, OperationTimeOut and ConnectionLoss: https://github.com/airbnb/nerve/blob/master/lib/nerve/reporter/zookeeper.rb#L8

Instead Zookeeper::Exceptions::NotConnected is treated as StandardError, which caused the thread that runs service watcher and reporter to be killed and restarted later. The restarted service watcher sets the [health status to nil](https://github.com/airbnb/nerve/blob/2de5f2855d095ab3fa31387d8da2e39825540ff5/lib/nerve/service_watcher.rb#L63) by default, and perform health check successfully, causing service reporter [tries to report up](https://github.com/airbnb/nerve/blob/2de5f2855d095ab3fa31387d8da2e39825540ff5/lib/nerve/service_watcher.rb#L155) again.

## Fix
Treat Zookeeper::Exceptions::NotConnected the same as `connection` errors, which goes through [re-try cycle](https://github.com/airbnb/nerve/blob/2de5f2855d095ab3fa31387d8da2e39825540ff5/lib/nerve/service_watcher.rb#L108) with delay in between before killing and restarting service watch thread until reach upper limit

@Ramyak @Jason-Jian @austin-zhu