### PR TITLE
Add path encoding optimization

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    nerve (0.8.8)
+    nerve (0.9.0)
       bunny (= 1.1.0)
       dogstatsd-ruby (~> 3.3.0)
       etcd (~> 0.2.3)

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ If you set your `reporter_type` to `"zookeeper"` you should also set these param
 
 * `zk_hosts`: a list of the zookeeper hosts comprising the [ensemble](https://zookeeper.apache.org/doc/r3.1.2/zookeeperAdmin.html#sc_zkMulitServerSetup) that nerve will submit registration to
 * `zk_path`: the path (or [znode](https://zookeeper.apache.org/doc/r3.1.2/zookeeperProgrammers.html#sc_zkDataModel_znodes)) where the registration will be created; nerve will create the [ephemeral node](https://zookeeper.apache.org/doc/r3.1.2/zookeeperProgrammers.html#Ephemeral+Nodes) that is the registration as a child of this path
+* `use_path_encoding`: flag to turn on path encoding optimization, the canonical config data at host level (e.g. ip, port, az) is encoded using json base64 and written as zk child name, the zk child data will still be written for backward compatibility
 
 #### Etcd Reporter ####
 

--- a/lib/nerve/reporter/zookeeper.rb
+++ b/lib/nerve/reporter/zookeeper.rb
@@ -134,7 +134,7 @@ class Nerve::Reporter
         if service.has_key?('labels')
           obj['labels'] = service['labels']
         end
-        '/' + Base64.urlsafe_encode64(JSON(obj)) + '_'
+        '/base64_' + Base64.urlsafe_encode64(JSON(obj)) + '_'
       else
         "/#{service['instance_id']}_"
       end

--- a/lib/nerve/reporter/zookeeper.rb
+++ b/lib/nerve/reporter/zookeeper.rb
@@ -127,11 +127,10 @@ class Nerve::Reporter
 
     def encode_child_name(service)
       if service['use_path_encoding'] == true
-        p @data
         encoded = Base64.urlsafe_encode64(@data)
         length = encoded.length
         statsd.gauge('nerve.reporter.zk.child.bytes', length, tags: ["zk_cluster:#{@zk_cluster}", "zk_path:#{@zk_path}"])
-        "/base64_#{encoded.length}_#{encoded}_"
+        "/base64_#{length}_#{encoded}_"
       else
         "/#{service['instance_id']}_"
       end

--- a/lib/nerve/reporter/zookeeper.rb
+++ b/lib/nerve/reporter/zookeeper.rb
@@ -22,7 +22,7 @@ class Nerve::Reporter
       @data = parse_data(get_service_data(service))
 
       @zk_path = service['zk_path']
-      @key_prefix = @zk_path + "/#{service['instance_id']}_"
+      @key_prefix = @zk_path + get_key(service)
       @full_key = nil
     end
 
@@ -122,6 +122,18 @@ class Nerve::Reporter
       # remove domain extents and trailing numbers
       last_non_number = first_token.rindex(/[^0-9]/)
       last_non_number ? first_token[0..last_non_number] : first_host
+    end
+
+    def get_key(service)
+      if service.has_key?('use_path_encoding') && service['use_path_encoding'] == true
+        key = "/#{service['host']}_#{service['port']}_"
+        if service.has_key?('labels') && service['labels'].has_key?('az')
+          key += "#{service['labels']['az']}_"
+        end
+        key
+      else
+        "/#{service['instance_id']}_"
+      end
     end
 
     def zk_delete

--- a/lib/nerve/reporter/zookeeper.rb
+++ b/lib/nerve/reporter/zookeeper.rb
@@ -2,6 +2,7 @@ require 'nerve/reporter/base'
 require 'thread'
 require 'zk'
 require 'zookeeper'
+require "base64"
 
 class Nerve::Reporter
   class Zookeeper < Base
@@ -126,11 +127,14 @@ class Nerve::Reporter
 
     def get_key(service)
       if service.has_key?('use_path_encoding') && service['use_path_encoding'] == true
-        key = "/#{service['host']}_#{service['port']}_"
+        obj = {
+          'host' => service['host'],
+          'port' => service['port']
+        }
         if service.has_key?('labels') && service['labels'].has_key?('az')
-          key += "#{service['labels']['az']}_"
+          obj['az'] = service['labels']['az']
         end
-        key
+        '/' + Base64.encode64(JSON(obj)) + '_'
       else
         "/#{service['instance_id']}_"
       end

--- a/lib/nerve/reporter/zookeeper.rb
+++ b/lib/nerve/reporter/zookeeper.rb
@@ -131,10 +131,8 @@ class Nerve::Reporter
           'host' => service['host'],
           'port' => service['port']
         }
-        if service.has_key?('labels') && service['labels'].has_key?('az')
-          obj['labels'] = {
-            'az' => service['labels']['az']
-          }
+        if service.has_key?('labels')
+          obj['labels'] = service['labels']
         end
         '/' + Base64.urlsafe_encode64(JSON(obj)) + '_'
       else

--- a/lib/nerve/reporter/zookeeper.rb
+++ b/lib/nerve/reporter/zookeeper.rb
@@ -134,7 +134,7 @@ class Nerve::Reporter
         if service.has_key?('labels') && service['labels'].has_key?('az')
           obj['az'] = service['labels']['az']
         end
-        '/' + Base64.encode64(JSON(obj)) + '_'
+        '/' + Base64.urlsafe_encode64(JSON(obj)) + '_'
       else
         "/#{service['instance_id']}_"
       end

--- a/lib/nerve/reporter/zookeeper.rb
+++ b/lib/nerve/reporter/zookeeper.rb
@@ -132,7 +132,9 @@ class Nerve::Reporter
           'port' => service['port']
         }
         if service.has_key?('labels') && service['labels'].has_key?('az')
-          obj['az'] = service['labels']['az']
+          obj['labels'] = {
+            'az' => service['labels']['az']
+          }
         end
         '/' + Base64.urlsafe_encode64(JSON(obj)) + '_'
       else

--- a/lib/nerve/version.rb
+++ b/lib/nerve/version.rb
@@ -1,3 +1,3 @@
 module Nerve
-  VERSION = "0.8.8"
+  VERSION = "0.9.0"
 end

--- a/spec/lib/nerve/reporter_zookeeper_spec.rb
+++ b/spec/lib/nerve/reporter_zookeeper_spec.rb
@@ -161,7 +161,13 @@ describe Nerve::Reporter::Zookeeper do
             'az' => 'us-east-1a'
           }
         }
-        expect(@reporter.send(:get_key, service)).to eq('/127.0.0.1_3000_us-east-1a_')
+        expected = {
+          'host' => '127.0.0.1',
+          'port' => 3000,
+          'az' => 'us-east-1a'
+        }
+        str = @reporter.send(:get_key, service)
+        JSON.parse(Base64.decode64(str[1...-1])).should == expected
       end
 
       it 'get key without az' do
@@ -170,7 +176,13 @@ describe Nerve::Reporter::Zookeeper do
           'host' => '127.0.0.1',
           'port' => 3000
         }
-        expect(@reporter.send(:get_key, service)).to eq('/127.0.0.1_3000_')
+        expected = {
+          'host' => '127.0.0.1',
+          'port' => 3000
+        }
+
+        str = @reporter.send(:get_key, service)
+        JSON.parse(Base64.decode64(str[1...-1])).should == expected
       end
 
       it 'get key with instance name' do

--- a/spec/lib/nerve/reporter_zookeeper_spec.rb
+++ b/spec/lib/nerve/reporter_zookeeper_spec.rb
@@ -167,7 +167,7 @@ describe Nerve::Reporter::Zookeeper do
           'az' => 'us-east-1a'
         }
         str = @reporter.send(:get_key, service)
-        JSON.parse(Base64.decode64(str[1...-1])).should == expected
+        JSON.parse(Base64.urlsafe_decode64(str[1...-1])).should == expected
       end
 
       it 'get key without az' do
@@ -182,7 +182,7 @@ describe Nerve::Reporter::Zookeeper do
         }
 
         str = @reporter.send(:get_key, service)
-        JSON.parse(Base64.decode64(str[1...-1])).should == expected
+        JSON.parse(Base64.urlsafe_decode64(str[1...-1])).should == expected
       end
 
       it 'get key with instance name' do

--- a/spec/lib/nerve/reporter_zookeeper_spec.rb
+++ b/spec/lib/nerve/reporter_zookeeper_spec.rb
@@ -18,7 +18,7 @@ describe Nerve::Reporter::Zookeeper do
     expect(Nerve::Reporter::Zookeeper.new(subject).is_a?(Nerve::Reporter::Zookeeper)).to eql(true)
   end
 
-  it 'deregisters serviceservice on exit' do
+  it 'deregisters service on exit' do
     allow(zk).to receive(:close!)
     allow(zk).to receive(:connected?).and_return(true)
     expect(zk).to receive(:exists?) { "zk_path" }.and_return(false)

--- a/spec/lib/nerve/reporter_zookeeper_spec.rb
+++ b/spec/lib/nerve/reporter_zookeeper_spec.rb
@@ -158,6 +158,7 @@ describe Nerve::Reporter::Zookeeper do
           'host' => '127.0.0.1',
           'port' => 3000,
           'labels' => {
+            'region' => 'us-east-1',
             'az' => 'us-east-1a'
           }
         }
@@ -165,6 +166,7 @@ describe Nerve::Reporter::Zookeeper do
           'host' => '127.0.0.1',
           'port' => 3000,
           'labels' => {
+            'region' => 'us-east-1',
             'az' => 'us-east-1a'
           }
         }

--- a/spec/lib/nerve/reporter_zookeeper_spec.rb
+++ b/spec/lib/nerve/reporter_zookeeper_spec.rb
@@ -171,7 +171,7 @@ describe Nerve::Reporter::Zookeeper do
           }
         }
         str = @reporter.send(:get_key, service)
-        JSON.parse(Base64.urlsafe_decode64(str[1...-1])).should == expected
+        JSON.parse(Base64.urlsafe_decode64(str[8...-1])).should == expected
       end
 
       it 'get key without az' do
@@ -186,7 +186,7 @@ describe Nerve::Reporter::Zookeeper do
         }
 
         str = @reporter.send(:get_key, service)
-        JSON.parse(Base64.urlsafe_decode64(str[1...-1])).should == expected
+        JSON.parse(Base64.urlsafe_decode64(str[8...-1])).should == expected
       end
 
       it 'get key with instance name' do

--- a/spec/lib/nerve/reporter_zookeeper_spec.rb
+++ b/spec/lib/nerve/reporter_zookeeper_spec.rb
@@ -164,7 +164,9 @@ describe Nerve::Reporter::Zookeeper do
         expected = {
           'host' => '127.0.0.1',
           'port' => 3000,
-          'az' => 'us-east-1a'
+          'labels' => {
+            'az' => 'us-east-1a'
+          }
         }
         str = @reporter.send(:get_key, service)
         JSON.parse(Base64.urlsafe_decode64(str[1...-1])).should == expected

--- a/spec/lib/nerve/reporter_zookeeper_spec.rb
+++ b/spec/lib/nerve/reporter_zookeeper_spec.rb
@@ -150,6 +150,39 @@ describe Nerve::Reporter::Zookeeper do
         expect {@reporter.report_down}.to raise_error(ZK::Exceptions::SessionExpired)
       end
     end
+
+    context "reporter path encoding" do
+      it 'get key with az' do
+        service = {
+          'use_path_encoding' => true,
+          'host' => '127.0.0.1',
+          'port' => 3000,
+          'labels' => {
+            'az' => 'us-east-1a'
+          }
+        }
+        expect(@reporter.send(:get_key, service)).to eq('/127.0.0.1_3000_us-east-1a_')
+      end
+
+      it 'get key without az' do
+        service = {
+          'use_path_encoding' => true,
+          'host' => '127.0.0.1',
+          'port' => 3000
+        }
+        expect(@reporter.send(:get_key, service)).to eq('/127.0.0.1_3000_')
+      end
+
+      it 'get key with instance name' do
+        service = {
+          'host' => '127.0.0.1',
+          'port' => 3000,
+          'instance_id' => 'i-0f93010ac7d8016ef'
+        }
+        expect(@reporter.send(:get_key, service)).to eq('/i-0f93010ac7d8016ef_')
+      end
+
+    end
   end
 end
 


### PR DESCRIPTION
### Summary:

1. encode zk child name with base64 encoding including ip, port, labels 
2. guard feature with flag `use_path_encoding ` so default behavior doesn't change
3. ensure backward compatibility: nerve with path encoding enabled works with old version of synapse safely
4. use variable length decoding to make schema more flexible:
   a. prefix is optional encoded json
   b. suffix is optional sequence number 
5. make encoding more producer driven
   a. feature is enabled based on child name prefixed with protocol name `base64_`
   b. json content is decided by data parsing, no fields picking

The counterpart synapse change:
https://github.com/airbnb/synapse/pull/296

### Test Plan:

test nerve config file:
```
{
  "instance_id": "macbook-pro",
  "listen_port": 1025,
  "services": {
    "mango-test_26009_secure": {
      "port": 3000,
      "check_interval": 2,
      "checks": [
        {
          "type": "tcp",
          "timeout": 1,
          "rise": 2,
          "fall": 2
        },
        {
          "type": "http",
          "uri": "/health",
          "timeout": 0.5,
          "rise": 2,
          "fall": 2,
          "host": "127.0.0.1",
          "port": 3000 
        }
      ],
      "zk_hosts": [
        "127.0.0.1:2181"
      ],
      "zk_path": "/mango-test/services",
      "host": "127.0.0.1",
      "labels": {
        "region": "us-east-1",
        "az": "us-east-1a"
      },
      "use_path_encoding": true
    }
  }
}
```

```
nerve --config nerve.json
I, [2019-07-02T18:33:45.876228 #2405]  INFO -- Nerve::Nerve: nerve: setting up!
I, [2019-07-02T18:33:45.878518 #2405]  INFO -- Module: nerve: configuring statsd on host 'localhost' port 8125
I, [2019-07-02T18:33:45.878547 #2405]  INFO -- Nerve::Nerve: nerve: starting main run loop
I, [2019-07-02T18:33:45.879281 #2405]  INFO -- Nerve::Nerve: nerve: loading config
I, [2019-07-02T18:33:45.879754 #2405]  INFO -- Module: nerve: configuring statsd on host 'localhost' port 8125
I, [2019-07-02T18:33:45.880121 #2405]  INFO -- Nerve::Nerve: nerve: launching new watchers: ["mango-test_26009_secure"]
I, [2019-07-02T18:33:45.928838 #2405]  INFO -- Nerve::ServiceWatcher: nerve: starting service watch mango-test_26009_secure
I, [2019-07-02T18:33:45.929018 #2405]  INFO -- Nerve::Reporter::Zookeeper: nerve: waiting to connect to zookeeper cluster 127.0.0.1:2181 hosts 127.0.0.1:2181
I, [2019-07-02T18:33:45.929046 #2405]  INFO -- Nerve::Reporter::Zookeeper: nerve: creating pooled connection to 127.0.0.1:2181
I, [2019-07-02T18:33:45.933940 #2405]  INFO -- Nerve::Reporter::Zookeeper: nerve: successfully created zk connection to 127.0.0.1:2181
I, [2019-07-02T18:33:45.934014 #2405]  INFO -- Nerve::Reporter::Zookeeper: nerve: retrieved zk connection to 127.0.0.1:2181
I, [2019-07-02T18:33:45.934834 #2405]  INFO -- Nerve::ServiceCheck::TcpServiceCheck: nerve: service check mango-test_26009_secure tcp-127.0.0.1:3000 initial check returned true
I, [2019-07-02T18:33:45.935975 #2405]  INFO -- Nerve::ServiceCheck::HttpServiceCheck: nerve: service check http-127.0.0.1:3000/health initial check returned true
I, [2019-07-02T18:33:45.937905 #2405]  INFO -- Nerve::ServiceWatcher: nerve: service mango-test_26009_secure is now up
```

```
zkCli ls /mango-test/services
Connecting to localhost:2181

WATCHER::

WatchedEvent state:SyncConnected type:None path:null
[eyJob3N0IjoiMTI3LjAuMC4xIiwicG9ydCI6MzAwMCwibGFiZWxzIjp7ImF6IjoidXMtZWFzdC0xYSJ9fQ==_0000000008]
```

compatibility test:
mango-test (synapse 0.16.13)-> mango-production (nerve 0.9.0)
<img width="881" alt="mango-production-enabled" src="https://user-images.githubusercontent.com/1474346/60632302-c1f3c600-9db9-11e9-9194-4ced31f99249.png">

<img width="1440" alt="old synapse with new nerve" src="https://user-images.githubusercontent.com/1474346/60632290-b1435000-9db9-11e9-80e0-1641e7e660ba.png">

mango-test (synapse 0.17.0) -> mango-production (nerve 0.9.0)
<img width="1226" alt="Screen Shot 2019-07-03 at 5 30 42 PM" src="https://user-images.githubusercontent.com/1474346/60632285-ac7e9c00-9db9-11e9-9d70-e81d4d313a90.png">

mango-test (synapse 0.17.0) -> mango-canary (nerve 0.8.8)
<img width="1206" alt="Screen Shot 2019-07-03 at 5 31 59 PM" src="https://user-images.githubusercontent.com/1474346/60632283-a8527e80-9db9-11e9-99e7-757e6bd72ff6.png">

### Reviewers:
@allenlsy @austin-zhu @Jason-Jian @Ramyak 