### PR TITLE
Add options for load testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: ruby
 cache: bundler
 sudo: false
 rvm:
-  - 1.9.3-p551
   - 2.0.0-p648
   - 2.1.10
   - 2.2.5

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ The configuration contains the following options:
 * `port`: the default port for service checks; nerve will report the `host`:`port` combo via your chosen reporter
 * `reporter_type`: the mechanism used to report up/down information; depending on the reporter you choose, additional parameters may be required. Defaults to `zookeeper`
 * `check_interval`: the frequency with which service checks will be initiated; defaults to `500ms`
+* `check_mocked`: whether or not health check is mocked, the host check always returns healthy and report up when the value is true
 * `checks`: a list of checks that nerve will perform; if all of the pass, the service will be registered; otherwise, it will be un-registered
 * `weight` (optional): a positive integer weight value which can be used to affect the haproxy backend weighting in synapse.
 * `haproxy_server_options` (optional): a string containing any special haproxy server options for this service instance. For example if you wanted to set a service instance as a backup.

--- a/lib/nerve.rb
+++ b/lib/nerve.rb
@@ -67,7 +67,17 @@ module Nerve
         raise ArgumentError, "you need to specify required argument #{required}" unless config[required]
       end
       @instance_id = config['instance_id']
-      @watchers_desired = config['services']
+      @watchers_desired = {}
+      config['services'].each do |key, value|
+        if value.key?('load_test_concurrency')
+          concurrenty = value['load_test_concurrency']
+          concurrenty.times do |i|
+            @watchers_desired["#{key}_#{i}"] = value
+          end
+        else
+          @watchers_desired[key] = value
+        end
+      end
       @max_repeated_report_failures = config['max_repeated_report_failures']
       @heartbeat_path = config['heartbeat_path']
       StatsD.configure_statsd(config["statsd"] || {})

--- a/lib/nerve/service_watcher.rb
+++ b/lib/nerve/service_watcher.rb
@@ -22,7 +22,7 @@ module Nerve
 
       @name = service['name']
 
-      # configure the reporter, which we use for reporting status to the registry 
+      # configure the reporter, which we use for reporting status to the registry
       @reporter = Reporter.new_from_service(service)
 
       # instantiate the checks for this service
@@ -58,6 +58,9 @@ module Nerve
 
       # how often do we initiate service checks?
       @check_interval = service['check_interval'] || 0.5
+
+      # mock service checks for load testing
+      @check_mocked = service['check_mocked'] || false
 
       # force an initial report on startup
       @was_up = nil
@@ -180,6 +183,9 @@ module Nerve
     end
 
     def check?
+      if @check_mocked
+        return true
+      end
       @service_checks.each do |check|
         up = check.up?
         statsd.increment('nerve.watcher.status.service_check', tags: ["check_result:#{up ? "up" : "down"}", "service_name:#{@name}", "check_name:#{check.name}"])

--- a/spec/lib/nerve/service_watcher_spec.rb
+++ b/spec/lib/nerve/service_watcher_spec.rb
@@ -20,8 +20,9 @@ describe Nerve::ServiceWatcher do
   end
 
   describe 'check_and_report' do
-    let(:service_watcher) { Nerve::ServiceWatcher.new(build(:service)) }
+    let(:service_watcher) { Nerve::ServiceWatcher.new(build(:service, :check_mocked => check_mocked)) }
     let(:reporter) { service_watcher.instance_variable_get(:@reporter) }
+    let(:check_mocked) { false }
 
     context 'when pinging of reporter succeeds' do
       it 'pings the reporter' do
@@ -42,7 +43,7 @@ describe Nerve::ServiceWatcher do
         expect(reporter).to receive(:report_up).and_return(true)
         expect(service_watcher.check_and_report).to be true
       end
-      
+
       context "when reporter failed to report up/down" do
         it 'returns false when report down' do
           expect(reporter).to receive(:ping?).and_return(true)
@@ -78,6 +79,15 @@ describe Nerve::ServiceWatcher do
         expect(reporter).not_to receive(:report_down)
 
         expect(service_watcher.check_and_report).to be false
+      end
+    end
+
+    context 'when check is mocked' do
+      let(:check_mocked) { true }
+      it 'report up no matter if host is up or down' do
+        expect(reporter).to receive(:ping?).and_return(true)
+        expect(reporter).to receive(:report_up).and_return(true)
+        expect(service_watcher.check_and_report).to be true
       end
     end
   end


### PR DESCRIPTION
For load testing purpose
1. add option `load_test_concurrency` to launch multiple service reporters 
2. add option `check_mocked` to skip host health check and always report up

Test with local zookeeper with test config:
```
{
  "instance_id": "macbook-pro",
  "listen_port": 1025,
  "services": {
    "mango-test_26009_secure": {
      "port": 3000,
      "check_interval": 2,
      "check_mocked": true,
      "checks": [
          {
              "type": "tcp",
              "timeout": 1,
              "rise": 2,
              "fall": 2
          },
          {
              "type": "http",
              "uri": "/health",
              "timeout": 0.5,
              "rise": 2,
              "fall": 2,
              "host": "127.0.0.1",
              "port": 3000
          }
      ],
      "zk_hosts": [
          "127.0.0.1:2181"
      ],
      "zk_path": "/mango-test/services",
      "host": "127.0.0.1",
      "labels": {
          "region": "us-east-1",
          "az": "us-east-1a"
      },
      "load_test_concurrency": 10
    }
  }
}

```

```
I, [2019-07-08T13:55:05.672843 #33805]  INFO -- Nerve::ServiceWatcher: nerve: service mango-test_26009_secure_1 is now up
I, [2019-07-08T13:55:05.673134 #33805]  INFO -- Nerve::ServiceWatcher: nerve: service mango-test_26009_secure_6 is now up
I, [2019-07-08T13:55:05.674680 #33805]  INFO -- Nerve::ServiceWatcher: nerve: service mango-test_26009_secure_3 is now up
I, [2019-07-08T13:55:05.675163 #33805]  INFO -- Nerve::Reporter::Zookeeper: nerve: re-using existing zookeeper connection to 127.0.0.1:2181
I, [2019-07-08T13:55:05.674721 #33805]  INFO -- Nerve::ServiceWatcher: nerve: service mango-test_26009_secure_8 is now up
I, [2019-07-08T13:55:05.675571 #33805]  INFO -- Nerve::Reporter::Zookeeper: nerve: retrieved zk connection to 127.0.0.1:2181
I, [2019-07-08T13:55:05.676637 #33805]  INFO -- Nerve::ServiceWatcher: nerve: service mango-test_26009_secure_5 is now up
I, [2019-07-08T13:55:05.677241 #33805]  INFO -- Nerve::ServiceWatcher: nerve: service mango-test_26009_secure_2 is now up
I, [2019-07-08T13:55:05.677545 #33805]  INFO -- Nerve::ServiceWatcher: nerve: service mango-test_26009_secure_7 is now up
I, [2019-07-08T13:55:05.679579 #33805]  INFO -- Nerve::ServiceWatcher: nerve: service mango-test_26009_secure_0 is now up
I, [2019-07-08T13:55:05.679926 #33805]  INFO -- Nerve::ServiceWatcher: nerve: service mango-test_26009_secure_4 is now up
I, [2019-07-08T13:55:05.681346 #33805]  INFO -- Nerve::ServiceWatcher: nerve: service mango-test_26009_secure_9 is now up
```
@Jason-Jian @austin-zhu @allenlsy @Ramyak 