### PR TITLE
Rate limit reporter updates

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    nerve (0.9.0)
+    nerve (0.9.1)
       bunny (= 1.1.0)
       dogstatsd-ruby (~> 3.3.0)
       etcd (~> 0.2.3)

--- a/README.md
+++ b/README.md
@@ -76,8 +76,8 @@ Rate limiting is configured in the `rate_limiting` hash. If enabled, rate limiti
 That hash contains the following values:
 
 * `shadow_mode` (optional): shadow mode emits metrics/logs for rate limiting, but does not actually throttle requests (defaults to `true`). Set to `false` to throttle requests.
-* `average_rate` (optional): enforced average rate limit for reporting (defaults to `10/s`)
-* `max_burst` (optional): enforced maximum burst for reporting (defaults to `100`)
+* `average_rate` (optional): enforced average rate limit for reporting (defaults to `infinity`)
+* `max_burst` (optional): enforced maximum burst for reporting (defaults to `infinity`)
 
 #### Zookeeper Reporter ####
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,9 @@ The configuration contains the following options:
 * `check_interval`: the frequency with which service checks will be initiated; defaults to `500ms`
 * `check_mocked`: whether or not health check is mocked, the host check always returns healthy and report up when the value is true
 * `checks`: a list of checks that nerve will perform; if all of the pass, the service will be registered; otherwise, it will be un-registered
+* `rate_limit_enabled` (optional): whether or not to enable rate limiting for reporting (defaults to `false`). If enabled, rate limiting is done via the [Token-Bucket algorithm](https://en.wikipedia.org/wiki/Token_bucket).
+* `rate_limit_avg` (optional): enforced average rate limit for reporting (defaults to `10/s`)
+* `rate_limit_burst` (optional): enforced maximum burst for reporting (defaults to `100`)
 * `weight` (optional): a positive integer weight value which can be used to affect the haproxy backend weighting in synapse.
 * `haproxy_server_options` (optional): a string containing any special haproxy server options for this service instance. For example if you wanted to set a service instance as a backup.
 * `labels` (optional): an object containing user-defined key-value pairs that describe this service instance. For example, you could label service instances with datacenter information.

--- a/README.md
+++ b/README.md
@@ -65,12 +65,19 @@ The configuration contains the following options:
 * `check_interval`: the frequency with which service checks will be initiated; defaults to `500ms`
 * `check_mocked`: whether or not health check is mocked, the host check always returns healthy and report up when the value is true
 * `checks`: a list of checks that nerve will perform; if all of the pass, the service will be registered; otherwise, it will be un-registered
-* `rate_limit_enabled` (optional): whether or not to enable rate limiting for reporting (defaults to `false`). If enabled, rate limiting is done via the [Token-Bucket algorithm](https://en.wikipedia.org/wiki/Token_bucket).
-* `rate_limit_avg` (optional): enforced average rate limit for reporting (defaults to `10/s`)
-* `rate_limit_burst` (optional): enforced maximum burst for reporting (defaults to `100`)
+* `rate_limiting` (optional): a hash containing the configuration for rate limiting (see 'Rate Limiting' below)
 * `weight` (optional): a positive integer weight value which can be used to affect the haproxy backend weighting in synapse.
 * `haproxy_server_options` (optional): a string containing any special haproxy server options for this service instance. For example if you wanted to set a service instance as a backup.
 * `labels` (optional): an object containing user-defined key-value pairs that describe this service instance. For example, you could label service instances with datacenter information.
+
+#### Rate Limiting ####
+
+Rate limiting is configured in the `rate_limiting` hash. If enabled, rate limiting is done via the [Token-Bucket algorithm](https://en.wikipedia.org/wiki/Token_bucket).
+That hash contains the following values:
+
+* `enabled` (optional): whether or not to enable rate limiting for reporting (defaults to `false`).
+* `average_rate` (optional): enforced average rate limit for reporting (defaults to `10/s`)
+* `max_burst` (optional): enforced maximum burst for reporting (defaults to `100`)
 
 #### Zookeeper Reporter ####
 
@@ -82,7 +89,7 @@ If you set your `reporter_type` to `"zookeeper"` you should also set these param
 
 #### Etcd Reporter ####
 
-Note: Etcd support is currently experimental! 
+Note: Etcd support is currently experimental!
 
 If you set your `reporter_type` to `"etcd"` you should also set these parameters:
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ The configuration contains the following options:
 Rate limiting is configured in the `rate_limiting` hash. If enabled, rate limiting is done via the [Token-Bucket algorithm](https://en.wikipedia.org/wiki/Token_bucket).
 That hash contains the following values:
 
-* `enabled` (optional): whether or not to enable rate limiting for reporting (defaults to `false`).
+* `shadow_mode` (optional): shadow mode emits metrics/logs for rate limiting, but does not actually throttle requests (defaults to `true`). Set to `false` to throttle requests.
 * `average_rate` (optional): enforced average rate limit for reporting (defaults to `10/s`)
 * `max_burst` (optional): enforced maximum burst for reporting (defaults to `100`)
 

--- a/lib/nerve/rate_limiter.rb
+++ b/lib/nerve/rate_limiter.rb
@@ -8,7 +8,9 @@ module Nerve
   class RateLimiter
     def initialize(average_rate: Float::INFINITY, max_burst: Float::INFINITY)
       raise ArgumentError, "average_rate should be numeric" unless average_rate.is_a? Numeric
+      raise ArgumentError, "average_rate should be positive or zero" unless average_rate >= 0
       raise ArgumentError, "max_burst should be numeric" unless max_burst.is_a? Numeric
+      raise ArgumentError, "max_burst should be >= 1" unless max_burst >= 1
 
       @average_rate = average_rate.to_f
       @max_burst = max_burst.to_f
@@ -21,6 +23,8 @@ module Nerve
     # and false otherwise. For a rate-limited action, the action should be
     # executed only when `consume` returns true.
     def consume
+      return true unless @average_rate.finite?
+
       refill_tokens
       return false unless @tokens >= 1
 
@@ -31,8 +35,6 @@ module Nerve
     private
 
     def refill_tokens
-      return nil unless @average_rate.finite?
-
       now = Time.now
       elapsed = now - @last_refill
       delta_tokens = (@average_rate * elapsed).floor

--- a/lib/nerve/rate_limiter.rb
+++ b/lib/nerve/rate_limiter.rb
@@ -1,0 +1,41 @@
+module Nerve
+  # RateLimiter implements a TokenBucket-based rate-limiting strategy.
+  # It allows an average of `average_rate` tokens per `period`, with a
+  # maximum burst of `max_burst` when the bucket is full.
+  # `period` is the time period for `average_rate`, in seconds.
+  # Note: a single instance of RateLimiter is *not* thread-safe.
+  # See: https://en.wikipedia.org/wiki/Token_bucket
+  class RateLimiter
+    def initialize(average_rate:, max_burst:, period: 1)
+      @average_rate = average_rate
+      @max_burst = max_burst
+      @period = period
+
+      @tokens = @average_rate
+      @last_refill = Time.now
+    end
+
+    # Consume a token, if one is available. Returns true if a token was consumed
+    # and false otherwise. For a rate-limited action, the action should be
+    # executed only when `consume` returns true.
+    def consume
+      refill_tokens
+      return false unless @tokens >= 1
+
+      @tokens -= 1
+      return true
+    end
+
+    private
+
+    def refill_tokens
+      now = Time.now
+      elapsed = (now - @last_refill).to_f / @period
+      delta_tokens = (@average_rate * elapsed).floor
+      return nil unless delta_tokens >= 1
+
+      @tokens = [@tokens + delta_tokens, @max_burst].min
+      @last_refill = now
+    end
+  end
+end

--- a/lib/nerve/rate_limiter.rb
+++ b/lib/nerve/rate_limiter.rb
@@ -6,7 +6,7 @@ module Nerve
   # Note: a single instance of RateLimiter is *not* thread-safe.
   # See: https://en.wikipedia.org/wiki/Token_bucket
   class RateLimiter
-    def initialize(average_rate:, max_burst:, period: 1)
+    def initialize(average_rate: 1, max_burst: 10, period: 1)
       raise TypeError, "average_rate should be numeric" unless average_rate.is_a? Numeric
       raise TypeError, "max_burst should be numeric" unless max_burst.is_a? Numeric
       raise TypeError, "period should be numeric" unless period.is_a? Numeric

--- a/lib/nerve/rate_limiter.rb
+++ b/lib/nerve/rate_limiter.rb
@@ -7,6 +7,10 @@ module Nerve
   # See: https://en.wikipedia.org/wiki/Token_bucket
   class RateLimiter
     def initialize(average_rate:, max_burst:, period: 1)
+      raise TypeError, "average_rate should be numeric" unless average_rate.is_a? Numeric
+      raise TypeError, "max_burst should be numeric" unless max_burst.is_a? Numeric
+      raise TypeError, "period should be numeric" unless period.is_a? Numeric
+
       @average_rate = average_rate
       @max_burst = max_burst
       @period = period

--- a/lib/nerve/rate_limiter.rb
+++ b/lib/nerve/rate_limiter.rb
@@ -7,13 +7,11 @@ module Nerve
   # See: https://en.wikipedia.org/wiki/Token_bucket
   class RateLimiter
     def initialize(average_rate: 1, max_burst: 10, period: 1)
-      raise TypeError, "average_rate should be numeric" unless average_rate.is_a? Numeric
-      raise TypeError, "max_burst should be numeric" unless max_burst.is_a? Numeric
-      raise TypeError, "period should be numeric" unless period.is_a? Numeric
+      raise ArgumentError, "average_rate should be numeric" unless average_rate.is_a? Numeric
+      raise ArgumentError, "max_burst should be numeric" unless max_burst.is_a? Numeric
 
       @average_rate = average_rate
       @max_burst = max_burst
-      @period = period
 
       @tokens = @average_rate
       @last_refill = Time.now
@@ -34,7 +32,7 @@ module Nerve
 
     def refill_tokens
       now = Time.now
-      elapsed = (now - @last_refill).to_f / @period
+      elapsed = now - @last_refill
       delta_tokens = (@average_rate * elapsed).floor
       return nil unless delta_tokens >= 1
 

--- a/lib/nerve/rate_limiter.rb
+++ b/lib/nerve/rate_limiter.rb
@@ -6,12 +6,12 @@ module Nerve
   # Note: a single instance of RateLimiter is *not* thread-safe.
   # See: https://en.wikipedia.org/wiki/Token_bucket
   class RateLimiter
-    def initialize(average_rate: 1, max_burst: 10, period: 1)
+    def initialize(average_rate: Float::INFINITY, max_burst: Float::INFINITY)
       raise ArgumentError, "average_rate should be numeric" unless average_rate.is_a? Numeric
       raise ArgumentError, "max_burst should be numeric" unless max_burst.is_a? Numeric
 
-      @average_rate = average_rate
-      @max_burst = max_burst
+      @average_rate = average_rate.to_f
+      @max_burst = max_burst.to_f
 
       @tokens = @average_rate
       @last_refill = Time.now
@@ -31,6 +31,8 @@ module Nerve
     private
 
     def refill_tokens
+      return nil unless @average_rate.finite?
+
       now = Time.now
       elapsed = now - @last_refill
       delta_tokens = (@average_rate * elapsed).floor

--- a/lib/nerve/rate_limiter.rb
+++ b/lib/nerve/rate_limiter.rb
@@ -25,10 +25,11 @@ module Nerve
     def consume
       return true unless @average_rate.finite?
 
-      refill_tokens
-      return false unless @tokens >= 1
+      new_tokens, now = refill_tokens
+      return false unless new_tokens >= 1
 
-      @tokens -= 1
+      @tokens = new_tokens - 1
+      @last_refill = now
       return true
     end
 
@@ -37,11 +38,9 @@ module Nerve
     def refill_tokens
       now = Time.now
       elapsed = now - @last_refill
-      delta_tokens = (@average_rate * elapsed).floor
-      return nil unless delta_tokens >= 1
+      delta_tokens = @average_rate * elapsed
 
-      @tokens = [@tokens + delta_tokens, @max_burst].min
-      @last_refill = now
+      return [@tokens + delta_tokens, @max_burst].min, now
     end
   end
 end

--- a/lib/nerve/service_watcher.rb
+++ b/lib/nerve/service_watcher.rb
@@ -27,9 +27,10 @@ module Nerve
       @reporter = Reporter.new_from_service(service)
 
       # configure the rate limiter for updates to the reporter
-      @rate_limiter = RateLimiter.new(average_rate: service['rate_limit_avg'] || 10,
-                                      max_burst: service['rate_limit_burst'] || 100)
-      @rate_limit_enabled = service.fetch('rate_limit_enabled', false)
+      rate_limit_config = service['rate_limiting'] || {}
+      @rate_limiter = RateLimiter.new(average_rate: rate_limit_config.fetch('average_rate', 10),
+                                      max_burst: rate_limit_config.fetch('max_burst', 100))
+      @rate_limit_enabled = rate_limit_config.fetch('enabled', false)
 
       # instantiate the checks for this service
       @service_checks = []

--- a/lib/nerve/service_watcher.rb
+++ b/lib/nerve/service_watcher.rb
@@ -30,7 +30,7 @@ module Nerve
       rate_limit_config = service['rate_limiting'] || {}
       @rate_limiter = RateLimiter.new(average_rate: rate_limit_config.fetch('average_rate', Float::INFINITY),
                                       max_burst: rate_limit_config.fetch('max_burst', Float::INFINITY))
-      @rate_limit_shadow_mode = rate_limit_config.fetch('shadow_mode', false)
+      @rate_limit_shadow_mode = rate_limit_config.fetch('shadow_mode', true)
 
       # instantiate the checks for this service
       @service_checks = []

--- a/lib/nerve/service_watcher.rb
+++ b/lib/nerve/service_watcher.rb
@@ -126,7 +126,7 @@ module Nerve
         when nil
           # this case exists for when the request is throttled
           # do nothing
-          log.debug "nerve: check_and_report returned #{report_succeeded} (rate limiter shadow mode: #{@rate_limit_shadow_mode})"
+          log.info "nerve: check_and_report returned #{report_succeeded} (rate limiter shadow mode: #{@rate_limit_shadow_mode})"
         end
 
         # wait to run more checks but make sure to exit if $EXIT

--- a/lib/nerve/service_watcher.rb
+++ b/lib/nerve/service_watcher.rb
@@ -126,7 +126,7 @@ module Nerve
         when nil
           # this case exists for when the request is throttled
           # do nothing
-          log.info "nerve: check_and_report returned #{report_succeeded} (rate limiter shadow mode: #{@rate_limit_shadow_mode})"
+          log.info "nerve: check_and_report returned nil (rate limiter shadow mode: #{@rate_limit_shadow_mode})"
         end
 
         # wait to run more checks but make sure to exit if $EXIT

--- a/lib/nerve/service_watcher.rb
+++ b/lib/nerve/service_watcher.rb
@@ -3,6 +3,7 @@ require 'nerve/service_watcher/http'
 require 'nerve/service_watcher/noop'
 require 'nerve/service_watcher/rabbitmq'
 require 'nerve/service_watcher/redis'
+require 'nerve/rate_limiter'
 
 module Nerve
   class ServiceWatcher
@@ -24,6 +25,10 @@ module Nerve
 
       # configure the reporter, which we use for reporting status to the registry
       @reporter = Reporter.new_from_service(service)
+
+      # configure the rate limiter for updates to the reporter
+      @rate_limiter = RateLimiter.new(average_rate: service['rate_limit_avg'] || 10,
+                                      max_burst: service['rate_limit_burst'] || 100)
 
       # instantiate the checks for this service
       @service_checks = []
@@ -111,10 +116,14 @@ module Nerve
       until watcher_should_exit? || repeated_report_failures >= @max_repeated_report_failures
         report_succeeded = check_and_report
 
-        if report_succeeded
+        case report_succeeded
+        when true
           repeated_report_failures = 0
-        else
+        when false
           repeated_report_failures += 1
+        when nil
+          # this case exists for when the request is throttled
+          # do nothing
         end
 
         # wait to run more checks but make sure to exit if $EXIT
@@ -154,6 +163,19 @@ module Nerve
 
       report_succeeded = true
       if is_up != @was_up
+        if ! @rate_limiter.consume
+          log.warn "nerve: service #{@name} throttled"
+          statsd.increment('nerve.watcher.throttled', tags: ["service_name:#{@name}"])
+
+          # When the request is throttled, ensure that the status is reported
+          # the next time around.
+          # This returns `nil` (instead of `false`) in order to avoid crashing
+          # the service watcher because of repeated failures. `nil` specifically
+          # reports that the requests were throttled.
+          @was_up = nil
+          return nil
+        end
+
         if is_up
           report_succeeded = @reporter.report_up
           if report_succeeded
@@ -169,6 +191,7 @@ module Nerve
             log.warn "nerve: service #{@name} failed to report down"
           end
         end
+
         @was_up = is_up
 
         if report_succeeded

--- a/lib/nerve/service_watcher.rb
+++ b/lib/nerve/service_watcher.rb
@@ -126,6 +126,7 @@ module Nerve
         when nil
           # this case exists for when the request is throttled
           # do nothing
+          log.debug "nerve: check_and_report returned #{report_succeeded} (rate limiter shadow mode: #{@rate_limit_shadow_mode})"
         end
 
         # wait to run more checks but make sure to exit if $EXIT

--- a/lib/nerve/service_watcher.rb
+++ b/lib/nerve/service_watcher.rb
@@ -28,8 +28,8 @@ module Nerve
 
       # configure the rate limiter for updates to the reporter
       rate_limit_config = service['rate_limiting'] || {}
-      @rate_limiter = RateLimiter.new(average_rate: rate_limit_config.fetch('average_rate', 10),
-                                      max_burst: rate_limit_config.fetch('max_burst', 100))
+      @rate_limiter = RateLimiter.new(average_rate: rate_limit_config.fetch('average_rate', Float::INFINITY),
+                                      max_burst: rate_limit_config.fetch('max_burst', Float::INFINITY))
       @rate_limit_shadow_mode = rate_limit_config.fetch('shadow_mode', false)
 
       # instantiate the checks for this service

--- a/lib/nerve/version.rb
+++ b/lib/nerve/version.rb
@@ -1,3 +1,3 @@
 module Nerve
-  VERSION = "0.9.0"
+  VERSION = "0.9.1"
 end

--- a/spec/lib/nerve/rate_limiter_spec.rb
+++ b/spec/lib/nerve/rate_limiter_spec.rb
@@ -1,0 +1,100 @@
+require 'spec_helper'
+require 'nerve/rate_limiter'
+require 'active_support/all'
+require 'active_support/testing/time_helpers'
+
+AVERAGE_RATE = 100
+MAX_BURST = 500
+PERIOD = 1
+
+describe Nerve::RateLimiter do
+  include ActiveSupport::Testing::TimeHelpers
+
+  describe 'initialize' do
+    it 'can successfully initialize without a period' do
+      Nerve::RateLimiter.new(average_rate: AVERAGE_RATE, max_burst: MAX_BURST)
+    end
+
+    it 'can successfully initialize with a period' do
+      Nerve::RateLimiter.new(average_rate: AVERAGE_RATE, max_burst: MAX_BURST, period: PERIOD)
+    end
+  end
+
+  describe 'consume' do
+    let!(:rate_limiter) {
+      Nerve::RateLimiter.new(average_rate: AVERAGE_RATE, max_burst: MAX_BURST, period: PERIOD)
+    }
+
+    context 'when no tokens have been consumed' do
+      it 'allows tokens to be consumed' do
+        expect(rate_limiter.consume).to be true
+      end
+
+      it 'allows up to the maximum burst' do
+        # Wait until there are enough tokens to hit the maximum burst
+        travel (MAX_BURST / AVERAGE_RATE + 1) * PERIOD
+
+        for _ in 1..MAX_BURST do
+          expect(rate_limiter.consume).to be true
+        end
+      end
+
+      it 'does not allow more than the maximum burst' do
+        # Wait until there are enough tokens to hit the maximum burst
+        travel (MAX_BURST / AVERAGE_RATE + 1) * PERIOD
+
+        for _ in 1..MAX_BURST do
+          rate_limiter.consume
+        end
+
+        expect(rate_limiter.consume).to be false
+      end
+    end
+
+    context 'when all tokens are consumed' do
+      before {
+        # consume up to the maximum burst
+        for _ in 1..MAX_BURST do
+          rate_limiter.consume
+        end
+      }
+
+      it 'does not allow tokens to be consumed' do
+        expect(rate_limiter.consume).to be false
+      end
+
+      it 'allows tokens to be consumed next period' do
+        travel PERIOD
+        expect(rate_limiter.consume).to be true
+      end
+    end
+
+    it 'only allows average rate over time' do
+      start_time = Time.now
+      count_success = 0
+      num_periods = 250
+
+      # Freeze time unless we manually move it.
+      travel_to start_time
+
+      # Clear all existing tokens.
+      while rate_limiter.consume do end
+
+      for period in 1..num_periods do
+        travel PERIOD
+
+        while rate_limiter.consume
+          count_success += 1
+        end
+
+        # Only check the average rate after a while, in which the rate will have
+        # been sustained enough to have an accurate average.
+        if period >= 0.1 * num_periods
+          elapsed_time = Time.now - start_time
+          avg_rate = count_success / elapsed_time
+          expect(avg_rate).to be_within(0.05 * AVERAGE_RATE).of AVERAGE_RATE
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/nerve/rate_limiter_spec.rb
+++ b/spec/lib/nerve/rate_limiter_spec.rb
@@ -22,6 +22,15 @@ describe Nerve::RateLimiter do
         Nerve::RateLimiter.new(average_rate: 1, max_burst: 'string')
       }.to raise_error ArgumentError
     end
+
+    it 'validates argument constraints' do
+      expect {
+        Nerve::RateLimiter.new(average_rate: -1, max_burst: 1)
+      }.to raise_error ArgumentError
+      expect{
+        Nerve::RateLimiter.new(average_rate: 1, max_burst: 0)
+      }.to raise_error ArgumentError
+    end
   end
 
   describe 'consume' do
@@ -70,6 +79,21 @@ describe Nerve::RateLimiter do
       it 'allows token to be consumed next period' do
         travel 1
         expect(rate_limiter.consume).to be true
+      end
+    end
+
+    context 'when the average rate is infinite' do
+      let!(:rate_limiter) {
+        Nerve::RateLimiter.new(average_rate: Float::INFINITY, max_burst: MAX_BURST)
+      }
+
+      it 'always allows tokens to be consumed' do
+        travel_to Time.now
+
+        # Should be able to consume more than the maximum burst
+        for _ in 1..(MAX_BURST * 2) do
+          expect(rate_limiter.consume).to be true
+        end
       end
     end
 

--- a/spec/lib/nerve/rate_limiter_spec.rb
+++ b/spec/lib/nerve/rate_limiter_spec.rb
@@ -18,6 +18,18 @@ describe Nerve::RateLimiter do
     it 'can successfully initialize with a period' do
       Nerve::RateLimiter.new(average_rate: AVERAGE_RATE, max_burst: MAX_BURST, period: PERIOD)
     end
+
+    it 'validates types of arguments' do
+      expect {
+        Nerve::RateLimiter.new(average_rate: 'string', max_burst: 1, period: 1)
+      }.to raise_error TypeError
+      expect{
+        Nerve::RateLimiter.new(average_rate: 1, max_burst: 'string', period: 1)
+      }.to raise_error TypeError
+      expect{
+        Nerve::RateLimiter.new(average_rate: 1, max_burst: 1, period: 'string')
+      }.to raise_error TypeError
+    end
   end
 
   describe 'consume' do

--- a/spec/lib/nerve/service_watcher_spec.rb
+++ b/spec/lib/nerve/service_watcher_spec.rb
@@ -27,7 +27,7 @@ describe Nerve::ServiceWatcher do
     let(:service_watcher) { Nerve::ServiceWatcher.new(build(:service, :check_mocked => check_mocked, :rate_limiting => rate_limit_config)) }
     let(:reporter) { service_watcher.instance_variable_get(:@reporter) }
     let(:check_mocked) { false }
-    let(:rate_limit_config) { {'enabled' => true} }
+    let(:rate_limit_config) { {'shadow_mode' => false} }
 
     context 'when pinging of reporter succeeds' do
       it 'pings the reporter' do
@@ -178,8 +178,8 @@ describe Nerve::ServiceWatcher do
       end
     end
 
-    context 'when rate limiting is disabled' do
-      let(:rate_limit_config) { {'enabled' => false} }
+    context 'when rate limiting is on shadow mode' do
+      let(:rate_limit_config) { {'shadow_mode' => true} }
 
       before {
           travel_to Time.now

--- a/spec/lib/nerve/service_watcher_spec.rb
+++ b/spec/lib/nerve/service_watcher_spec.rb
@@ -1,7 +1,11 @@
 require 'spec_helper'
 require 'timeout'
+require 'active_support/all'
+require 'active_support/testing/time_helpers'
 
 describe Nerve::ServiceWatcher do
+  include ActiveSupport::Testing::TimeHelpers
+
   describe 'initialize' do
     let(:service) { build(:service) }
 
@@ -60,6 +64,52 @@ describe Nerve::ServiceWatcher do
         end
       end
 
+      context 'when throttled' do
+        before {
+          # Freeze time
+          travel_to Time.now
+
+          allow(reporter).to receive(:ping?).and_return(true)
+          allow(service_watcher).to receive(:check?).and_return(true)
+
+          # 100 is maximum burst
+          for _ in 0..100
+            service_watcher.check_and_report
+            service_watcher.instance_variable_set(:@was_up, false)
+          end
+        }
+
+        it 'still pings reporter' do
+          expect(reporter).to receive(:ping?)
+          service_watcher.check_and_report
+        end
+
+        it 'still checks service health' do
+          expect(reporter).to receive(:ping?).and_return(true)
+          expect(service_watcher).to receive(:check?)
+          service_watcher.check_and_report
+        end
+
+        it 'doesn\'t try to report' do
+          expect(reporter).to receive(:ping?).and_return(true)
+          expect(service_watcher).to receive(:check?).and_return(true)
+
+          expect(reporter).not_to receive(:report_up)
+          expect(reporter).not_to receive(:report_down)
+          expect(service_watcher.check_and_report).to be nil
+        end
+
+        it 'reports new status when no longer throttled' do
+          # Increasing time will remove the throttle
+          travel 1.minute
+
+          expect(reporter).to receive(:ping?).and_return(true)
+          expect(service_watcher).to receive(:check?).and_return(true)
+          expect(reporter).to receive(:report_up).and_return(true)
+          expect(service_watcher.check_and_report).to be true
+        end
+      end
+
       it 'doesn\'t report if the status hasn\'t changed' do
         expect(reporter).to receive(:ping?).and_return(true)
         expect(service_watcher).to receive(:check?).and_return(true)
@@ -69,8 +119,47 @@ describe Nerve::ServiceWatcher do
         expect(reporter).not_to receive(:report_down)
         expect(service_watcher.check_and_report).to be true
       end
-    end
 
+      context 'when the service is flappy' do
+        before {
+          # freeze time
+          travel_to Time.now
+
+          allow(reporter).to receive(:ping?).and_return(true)
+          allow(service_watcher).to receive(:check?) { rand() >= 0.5 }
+
+          for _ in 0..100
+            service_watcher.check_and_report
+          end
+        }
+
+        it 'throttles reporting' do
+          expect(reporter).not_to receive(:report_up)
+          expect(reporter).not_to receive(:report_down)
+          expect(service_watcher.check_and_report).to be nil
+        end
+      end
+
+      context 'when the service is operating normally' do
+        before {
+          travel_to Time.now
+
+          allow(reporter).to receive(:ping?).and_return(true)
+          allow(service_watcher).to receive(:check?).and_return(true)
+
+          for _ in 0..100
+            service_watcher.check_and_report
+          end
+        }
+
+        it 'does not throttle reporting' do
+          # force a new report
+          service_watcher.instance_variable_set(:@was_up, false)
+          expect(reporter).to receive(:report_up).and_return(true)
+          expect(service_watcher.check_and_report).to be true
+        end
+      end
+    end
 
     context 'when pinging of reporter fails' do
       it 'doesn\'t try to report' do
@@ -79,6 +168,12 @@ describe Nerve::ServiceWatcher do
         expect(reporter).not_to receive(:report_down)
 
         expect(service_watcher.check_and_report).to be false
+      end
+
+      it 'does not throttle' do
+        for _ in 0..100 do
+          expect(service_watcher.check_and_report).not_to be nil
+        end
       end
     end
 

--- a/spec/lib/nerve/service_watcher_spec.rb
+++ b/spec/lib/nerve/service_watcher_spec.rb
@@ -24,10 +24,10 @@ describe Nerve::ServiceWatcher do
   end
 
   describe 'check_and_report' do
-    let(:service_watcher) { Nerve::ServiceWatcher.new(build(:service, :check_mocked => check_mocked, :rate_limit_enabled => rate_limit_enabled)) }
+    let(:service_watcher) { Nerve::ServiceWatcher.new(build(:service, :check_mocked => check_mocked, :rate_limiting => rate_limit_config)) }
     let(:reporter) { service_watcher.instance_variable_get(:@reporter) }
     let(:check_mocked) { false }
-    let(:rate_limit_enabled) { true }
+    let(:rate_limit_config) { {'enabled' => true} }
 
     context 'when pinging of reporter succeeds' do
       it 'pings the reporter' do
@@ -179,7 +179,7 @@ describe Nerve::ServiceWatcher do
     end
 
     context 'when rate limiting is disabled' do
-      let(:rate_limit_enabled) { false }
+      let(:rate_limit_config) { {'enabled' => false} }
 
       before {
           travel_to Time.now

--- a/spec/lib/nerve/service_watcher_spec.rb
+++ b/spec/lib/nerve/service_watcher_spec.rb
@@ -27,7 +27,8 @@ describe Nerve::ServiceWatcher do
     let(:service_watcher) { Nerve::ServiceWatcher.new(build(:service, :check_mocked => check_mocked, :rate_limiting => rate_limit_config)) }
     let(:reporter) { service_watcher.instance_variable_get(:@reporter) }
     let(:check_mocked) { false }
-    let(:rate_limit_config) { {'shadow_mode' => false} }
+    let(:rate_limit_config) { {'shadow_mode' => rate_limit_shadow_mode, 'average_rate' => 10, 'max_burst' => 100} }
+    let(:rate_limit_shadow_mode) { false }
 
     context 'when pinging of reporter succeeds' do
       it 'pings the reporter' do
@@ -179,7 +180,7 @@ describe Nerve::ServiceWatcher do
     end
 
     context 'when rate limiting is on shadow mode' do
-      let(:rate_limit_config) { {'shadow_mode' => true} }
+      let(:rate_limit_shadow_mode) { true }
 
       before {
           travel_to Time.now


### PR DESCRIPTION
# Problem

When a service is flappy (i.e. changes healthy vs. unhealthy status frequently) it will have high write throughput to the reporter because each status change is reported.

# Solution

Use rate limiting in order to throttle the reporter updates. The average rate/maximum burst is configurable, and rate limiting is off by default. 

# Testing

Added unit tests for both the `RateLimiter` class and its integration into `ServiceWatcher`. The average rate and maximum burst are tested, as well as checking that reports are not throttled when the rate limiter is disabled.

Also tested using `mango-test`:

## Rate-limiting enabled
For this test, I configured rate-limiting to only allow 1 report per 10 seconds. As shown, after the reports are no longer throttled (i.e. after 10 seconds from the previous report), the new status is reported.

```
----> I, [2019-09-25T21:22:27.085264 #4004]  INFO -- Nerve::ServiceWatcher: nerve: service mango-test_26009_secure is now up
W, [2019-09-25T21:22:31.131430 #4004]  WARN -- Nerve::ServiceCheck::HttpServiceCheck: nerve: check http-127.0.0.1:80/health got response code 502 with body "<html>
<head><title>502 Bad Gateway</title></head>
<body bgcolor="white">
<center><h1>502 Bad Gateway</h1></center>
<hr><center>nginx</center>
</body>
</html>
"
...
I, [2019-09-25T21:22:31.633595 #4004]  INFO -- Nerve::ServiceCheck::HttpServiceCheck: nerve: service check http-127.0.0.1:80/health transitions to down after 2 failures
W, [2019-09-25T21:22:31.633696 #4004]  WARN -- Nerve::ServiceWatcher: nerve: service mango-test_26009_secure throttled (rate limiter enabled: true)
...
----> W, [2019-09-25T21:22:37.159856 #4004]  WARN -- Nerve::ServiceWatcher: nerve: service mango-test_26009_secure is now down
I, [2019-09-25T21:22:39.225242 #4004]  INFO -- Nerve::ServiceCheck::HttpServiceCheck: nerve: service check http-127.0.0.1:80/health transitions to up after 2 successes
W, [2019-09-25T21:22:39.225375 #4004]  WARN -- Nerve::ServiceWatcher: nerve: service mango-test_26009_secure throttled (rate limiter enabled: true)
W, [2019-09-25T21:22:39.731685 #4004]  WARN -- Nerve::ServiceWatcher: nerve: service mango-test_26009_secure throttled (rate limiter enabled: true)
...
----> I, [2019-09-25T21:22:47.349001 #4004]  INFO -- Nerve::ServiceWatcher: nerve: service mango-test_26009_secure is now up
```

From metrics, the number of reports is far lower than the number of attempted reports (which were throttled):

![image](https://user-images.githubusercontent.com/6776539/65726089-1204c080-e069-11e9-82c6-7a19719c113f.png)
![image](https://user-images.githubusercontent.com/6776539/65726094-14ffb100-e069-11e9-86e9-b6c39c9666b8.png)


## Rate-limiting disabled
With rate-limiting disabled, logs and metrics are still released (when a report _would_ have been throttled) which you can see here. However, the report still goes through.

```
I, [2019-09-26T18:03:47.677764 #19718]  INFO -- Nerve::ServiceCheck::HttpServiceCheck: nerve: service check http-127.0.0.1:80/health transitions to up after 2 successes
----> W, [2019-09-26T18:03:47.677878 #19718]  WARN -- Nerve::ServiceWatcher: nerve: service mango-test_26009_secure throttled (rate limiter enabled: false)
----> I, [2019-09-26T18:03:47.681427 #19718]  INFO -- Nerve::ServiceWatcher: nerve: service mango-test_26009_secure is now up
W, [2019-09-26T18:03:53.693957 #19718]  WARN -- Nerve::ServiceCheck::HttpServiceCheck: nerve: check http-127.0.0.1:80/health got response code 502 with body "<html>
<head><title>502 Bad Gateway</title></head>
<body bgcolor="white">
<center><h1>502 Bad Gateway</h1></center>
<hr><center>nginx</center>
</body>
</html>
"
I, [2019-09-26T18:03:53.694049 #19718]  INFO -- Nerve::ServiceCheck::HttpServiceCheck: nerve: service check http-127.0.0.1:80/health transitions to down after 2 failures
W, [2019-09-26T18:03:53.696531 #19718]  WARN -- Nerve::ServiceWatcher: nerve: service mango-test_26009_secure is now down
…
I, [2019-09-26T18:04:01.764030 #19718]  INFO -- Nerve::ServiceCheck::HttpServiceCheck: nerve: service check http-127.0.0.1:80/health transitions to up after 2 successes
----> W, [2019-09-26T18:04:01.764150 #19718]  WARN -- Nerve::ServiceWatcher: nerve: service mango-test_26009_secure throttled (rate limiter enabled: false)
----> I, [2019-09-26T18:04:01.768049 #19718]  INFO -- Nerve::ServiceWatcher: nerve: service mango-test_26009_secure is now up
```

With rate-limiting disabled, the number of reports (for up+down) is equal to the number of "throttles" (because no report is actually blocked):

![image](https://user-images.githubusercontent.com/6776539/65726151-36f93380-e069-11e9-9cbb-610dbccc4d27.png)
![image](https://user-images.githubusercontent.com/6776539/65726153-38c2f700-e069-11e9-8f15-2e2471a86774.png)

# Reviewers

@anson627 @Jason-Jian @austin-zhu 