### PR TITLE
Make Nerve compatible with Ruby 1.9.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: ruby
 cache: bundler
 sudo: false
 rvm:
+  - 1.9.3
   - 2.0.0-p648
   - 2.1.10
   - 2.2.5

--- a/lib/nerve/rate_limiter.rb
+++ b/lib/nerve/rate_limiter.rb
@@ -6,7 +6,10 @@ module Nerve
   # Note: a single instance of RateLimiter is *not* thread-safe.
   # See: https://en.wikipedia.org/wiki/Token_bucket
   class RateLimiter
-    def initialize(average_rate: Float::INFINITY, max_burst: Float::INFINITY)
+    def initialize(options = {})
+      average_rate = options[:average_rate] || Float::Infinity
+      max_burst = options[:max_burst] || Float::Infinity
+
       raise ArgumentError, "average_rate should be numeric" unless average_rate.is_a? Numeric
       raise ArgumentError, "average_rate should be positive or zero" unless average_rate >= 0
       raise ArgumentError, "max_burst should be numeric" unless max_burst.is_a? Numeric


### PR DESCRIPTION
Also added Ruby 1.9.3 to CI

@anson627 