### PR TITLE
Add Nerve version info to ping metric

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    nerve (0.9.3)
+    nerve (0.9.4)
       bunny (= 1.1.0)
       dogstatsd-ruby (~> 3.3.0)
       etcd (~> 0.2.3)

--- a/lib/nerve/service_watcher.rb
+++ b/lib/nerve/service_watcher.rb
@@ -4,6 +4,7 @@ require 'nerve/service_watcher/noop'
 require 'nerve/service_watcher/rabbitmq'
 require 'nerve/service_watcher/redis'
 require 'nerve/rate_limiter'
+require 'nerve/version'
 
 module Nerve
   class ServiceWatcher
@@ -151,14 +152,14 @@ module Nerve
 
     def check_and_report
       if !@reporter.ping?
-        statsd.increment('nerve.watcher.status.ping.count', tags: ["ping_result:fail", "service_name:#{@name}"])
+        statsd.increment('nerve.watcher.status.ping.count', tags: ["ping_result:fail", "service_name:#{@name}", "nerve_version:#{VERSION}"])
 
         # If the reporter can't ping, then we do not know the status and must force a new report.
         # We will also skip checking service status since it couldn't be reported
         @was_up = nil
         return false
       end
-      statsd.increment('nerve.watcher.status.ping.count', tags: ["ping_result:success", "service_name:#{@name}"])
+      statsd.increment('nerve.watcher.status.ping.count', tags: ["ping_result:success", "service_name:#{@name}", "nerve_version:#{VERSION}"])
 
       # what is the status of the service?
       is_up = check?

--- a/lib/nerve/version.rb
+++ b/lib/nerve/version.rb
@@ -1,3 +1,3 @@
 module Nerve
-  VERSION = "0.9.3"
+  VERSION = "0.9.4"
 end


### PR DESCRIPTION
This adds metrics about the Nerve version per-ping. Tested by checking that metrics are properly emitted on a specific host.