### PR TITLE
Add simplecov and simplecov-json

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -23,6 +23,7 @@ GEM
       amq-protocol (>= 1.9.2)
     coderay (1.1.0)
     diff-lcs (1.2.5)
+    docile (1.3.2)
     dogstatsd-ruby (3.3.0)
     etcd (0.2.4)
       mixlib-log
@@ -51,6 +52,14 @@ GEM
     rspec-mocks (3.1.3)
       rspec-support (~> 3.1.0)
     rspec-support (3.1.2)
+    simplecov (0.17.1)
+      docile (~> 1.1)
+      json (>= 1.8, < 3)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.2)
+    simplecov-json (0.2)
+      json
+      simplecov
     slop (3.6.0)
     thread_safe (0.3.4)
     tzinfo (1.2.2)
@@ -68,6 +77,8 @@ DEPENDENCIES
   pry
   rake
   rspec (~> 3.1.0)
+  simplecov (~> 0.16)
+  simplecov-json (~> 0.2)
 
 BUNDLED WITH
    1.16.1

--- a/nerve.gemspec
+++ b/nerve.gemspec
@@ -32,4 +32,6 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "rspec", "~> 3.1.0"
   gem.add_development_dependency "factory_girl"
   gem.add_development_dependency "pry"
+  gem.add_development_dependency "simplecov", "~> 0.16"
+  gem.add_development_dependency "simplecov-json", "~> 0.2"
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,25 @@
 # loaded once.
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
+if ENV["CODE_COVERAGE"] == "true"
+  # SimpleCov must be started before anything else is loaded.
+  require "simplecov"
+  require "simplecov-json"
+
+  SimpleCov.start do
+    # Any not-loaded files matching this glob will be counted as having 0% coverage.
+    track_files "lib/**/*.rb"
+
+    # SimpleCov won't track coverage in files whose paths match these strings.
+    add_filter [
+      "/spec/",
+      "/version.rb", # Loads in advance with `bundle exec`.
+    ]
+
+    formatter SimpleCov::Formatter::JSONFormatter
+  end
+end
+
 require "#{File.dirname(__FILE__)}/../lib/nerve"
 
 require 'factory_girl'


### PR DESCRIPTION
#### Summary
This change adds simplecov and simplecov-json to report code coverage.
To get code coverage information in your build you need to set the
CODE_COVERAGE env var to "true"

#### Test Plan
- [X] bundle exec rspec

#### Reviewers
@panchr 