### PR TITLE
[ci] Fix running CI on Ruby 2.3.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,5 @@ rvm:
   - 2.1.10
   - 2.2.5
   - 2.3.1
+before_install:
+  - gem install bundler -v 1.16.1


### PR DESCRIPTION
## Summary
Because of an unspecified Bundler version, CI broke on Ruby 2.3.1.
For example, see: https://travis-ci.org/airbnb/nerve/jobs/649609864.

This mimics the CI configuration in [airbnb/synapse](https://github.com/airbnb/synapse/blob/ac8657f25c433c71d3d72e777bf28b56cd3c60c5/.travis.yml#L11).

## Tests
- [x] CI passes

## Reviewers
@lcharignon 