### PR TITLE
add option to customize ZK node type

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    nerve (0.9.4)
+    nerve (0.9.5)
       bunny (= 1.1.0)
       dogstatsd-ruby (~> 3.3.0)
       etcd (~> 0.2.3)

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ If you set your `reporter_type` to `"zookeeper"` you should also set these param
 * `zk_hosts`: a list of the zookeeper hosts comprising the [ensemble](https://zookeeper.apache.org/doc/r3.1.2/zookeeperAdmin.html#sc_zkMulitServerSetup) that nerve will submit registration to
 * `zk_path`: the path (or [znode](https://zookeeper.apache.org/doc/r3.1.2/zookeeperProgrammers.html#sc_zkDataModel_znodes)) where the registration will be created
 * `use_path_encoding`: optional flag to turn on path encoding optimization, the canonical config data at host level (e.g. ip, port, az) is encoded using json base64 and written as zk child name, the zk child data will still be written for backward compatibility
-* `node_type`: the [type](https://zookeeper.apache.org/doc/r3.1.2/zookeeperProgrammers.html#Ephemeral+Nodes) of znode that nerve will register as. The available types are `ephemeral_sequential`, `persistent_sequential`, `persistent` and `ephemeral`. If not specified, nerve will create the znode as `ephemeral_sequential` type by default
+* `node_type`: the [type](https://zookeeper.apache.org/doc/r3.1.2/zookeeperProgrammers.html#Ephemeral+Nodes) of znode that nerve will register as. The available types are `ephemeral_sequential`, `persistent_sequential`, `persistent`, and `ephemeral`. If not specified, nerve will create the znode as `ephemeral_sequential` type by default
 
 #### Etcd Reporter ####
 

--- a/README.md
+++ b/README.md
@@ -91,8 +91,9 @@ That hash contains the following values:
 If you set your `reporter_type` to `"zookeeper"` you should also set these parameters:
 
 * `zk_hosts`: a list of the zookeeper hosts comprising the [ensemble](https://zookeeper.apache.org/doc/r3.1.2/zookeeperAdmin.html#sc_zkMulitServerSetup) that nerve will submit registration to
-* `zk_path`: the path (or [znode](https://zookeeper.apache.org/doc/r3.1.2/zookeeperProgrammers.html#sc_zkDataModel_znodes)) where the registration will be created; nerve will create the [ephemeral node](https://zookeeper.apache.org/doc/r3.1.2/zookeeperProgrammers.html#Ephemeral+Nodes) that is the registration as a child of this path
-* `use_path_encoding`: flag to turn on path encoding optimization, the canonical config data at host level (e.g. ip, port, az) is encoded using json base64 and written as zk child name, the zk child data will still be written for backward compatibility
+* `zk_path`: the path (or [znode](https://zookeeper.apache.org/doc/r3.1.2/zookeeperProgrammers.html#sc_zkDataModel_znodes)) where the registration will be created
+* `use_path_encoding`: optional flag to turn on path encoding optimization, the canonical config data at host level (e.g. ip, port, az) is encoded using json base64 and written as zk child name, the zk child data will still be written for backward compatibility
+* `node_type`: the [type](https://zookeeper.apache.org/doc/r3.1.2/zookeeperProgrammers.html#Ephemeral+Nodes) of znode that nerve will register as. The available types are `ephemeral_sequential`, `persistent_sequential`, `persistent` and `ephemeral`. If not specified, nerve will create the znode as `ephemeral_sequential` type by default
 
 #### Etcd Reporter ####
 

--- a/lib/nerve/version.rb
+++ b/lib/nerve/version.rb
@@ -1,3 +1,3 @@
 module Nerve
-  VERSION = "0.9.4"
+  VERSION = "0.9.5"
 end


### PR DESCRIPTION
## Summary
Currently, nerve only registers to ZK as the hard-coded type of `:ephemeral_sequential`. Nerve could provide the flexibility to register as other different types, for example, `:persistent` type.

To keep back compatibility, the type is still `:ephemeral_sequential` if not specified.

NOTE: when using `persistent-*` type, it might cause stale data in ZK if the graceful shutdown doesn't invoke or failed executing.

## Reviewers
@anson627 @panchr 

## Test

- Unit tests
- Create a service with different node types to register, they are `N/A`, `'ephemeral'`, `'persistent'`, `'ephemeral_sequential'` and `persistent_sequential`, respectively
- Verify that nodes were created to ZK successfully
![image](https://user-images.githubusercontent.com/19193590/74380071-bdef4400-4d9d-11ea-814a-0453cb40334c.png)
- Verify that the node type is desired
```
 ~/airlab/repos/nerve | austin--customize-node-type ❯ zkCli -server zk-test0.us-east-1.prod.musta.ch:2181 get /production/secure/services/mango-test/no-node-type/base64_156_eyJob3N0IjoiMTcyLjIxLjEwOS4yMjQiLCJwb3J0IjoyNjAwOSwibmFtZSI6ImktMGQ1N2EzMzA1NDk1NTlkZDQiLCJsYWJlbHMiOnsicmVnaW9uIjoidXMtZWFzdC0xIiwiYXoiOiJ1cy1lYXN0LTFlIn19_0000000003 2>&1 | grep ephemeralOwner
ephemeralOwner = 0x696db2eef8dc00f9
 ~/airlab/repos/nerve | austin--customize-node-type ❯ zkCli -server zk-test0.us-east-1.prod.musta.ch:2181 get /production/secure/services/mango-test/ephemeral-node-type/base64_156_eyJob3N0IjoiMTcyLjIxLjEwOS4yMjQiLCJwb3J0IjoyNjAwOSwibmFtZSI6ImktMGQ1N2EzMzA1NDk1NTlkZDQiLCJsYWJlbHMiOnsicmVnaW9uIjoidXMtZWFzdC0xIiwiYXoiOiJ1cy1lYXN0LTFlIn19_ 2>&1 | grep ephemeralOwner
ephemeralOwner = 0x696db2eef8dc00f9
 ~/airlab/repos/nerve | austin--customize-node-type ❯ zkCli -server zk-test0.us-east-1.prod.musta.ch:2181 get /production/secure/services/mango-test/persistent-node-type/base64_156_eyJob3N0IjoiMTcyLjIxLjEwOS4yMjQiLCJwb3J0IjoyNjAwOSwibmFtZSI6ImktMGQ1N2EzMzA1NDk1NTlkZDQiLCJsYWJlbHMiOnsicmVnaW9uIjoidXMtZWFzdC0xIiwiYXoiOiJ1cy1lYXN0LTFlIn19_ 2>&1 | grep ephemeralOwner
ephemeralOwner = 0x0
 ~/airlab/repos/nerve | austin--customize-node-type ❯ zkCli -server zk-test0.us-east-1.prod.musta.ch:2181 get /production/secure/services/mango-test/ephemeral-sequential-node-type/base64_156_eyJob3N0IjoiMTcyLjIxLjEwOS4yMjQiLCJwb3J0IjoyNjAwOSwibmFtZSI6ImktMGQ1N2EzMzA1NDk1NTlkZDQiLCJsYWJlbHMiOnsicmVnaW9uIjoidXMtZWFzdC0xIiwiYXoiOiJ1cy1lYXN0LTFlIn19_0000000003 2>&1 | grep ephemeralOwner
ephemeralOwner = 0x696db2eef8dc00f9
 ~/airlab/repos/nerve | austin--customize-node-type ❯ zkCli -server zk-test0.us-east-1.prod.musta.ch:2181 get /production/secure/services/mango-test/persistent-sequential-node-type/base64_156_eyJob3N0IjoiMTcyLjIxLjEwOS4yMjQiLCJwb3J0IjoyNjAwOSwibmFtZSI6ImktMGQ1N2EzMzA1NDk1NTlkZDQiLCJsYWJlbHMiOnsicmVnaW9uIjoidXMtZWFzdC0xIiwiYXoiOiJ1cy1lYXN0LTFlIn19_0000000003 2>&1 | grep ephemeralOwner
ephemeralOwner = 0x0
```
- Cut the connection to ZK by modifying iptable. Verify that the `ephemeral-*` nodes are removed after session timeout (5 secs), but not `persistent-*` node.
![image](https://user-images.githubusercontent.com/19193590/74382593-9058c980-4da2-11ea-8e74-0af62c860b78.png)

- Verify when gracefully shutdown, all types of nodes will be removed.
![image](https://user-images.githubusercontent.com/19193590/74397808-67e4c580-4dca-11ea-8c71-61d1632ae1e1.png)

