### PR TITLE
Add option to Zookeeper reporter to periodically "touch" node

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    nerve (0.9.5)
+    nerve (0.9.6)
       bunny (= 1.1.0)
       dogstatsd-ruby (~> 3.3.0)
       etcd (~> 0.2.3)

--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ If you set your `reporter_type` to `"zookeeper"` you should also set these param
 * `zk_path`: the path (or [znode](https://zookeeper.apache.org/doc/r3.1.2/zookeeperProgrammers.html#sc_zkDataModel_znodes)) where the registration will be created
 * `use_path_encoding`: optional flag to turn on path encoding optimization, the canonical config data at host level (e.g. ip, port, az) is encoded using json base64 and written as zk child name, the zk child data will still be written for backward compatibility
 * `node_type`: the [type](https://zookeeper.apache.org/doc/r3.1.2/zookeeperProgrammers.html#Ephemeral+Nodes) of znode that nerve will register as. The available types are `ephemeral_sequential`, `persistent_sequential`, `persistent`, and `ephemeral`. If not specified, nerve will create the znode as `ephemeral_sequential` type by default
+* `ttl_seconds`: repeatedly 'touch' the created node at this interval in order to update the `mtime`. If nil (the default), it will not perform this periodic update.
 
 #### Etcd Reporter ####
 

--- a/lib/nerve/atomic.rb
+++ b/lib/nerve/atomic.rb
@@ -2,7 +2,7 @@ require 'thread'
 
 module Nerve
   class AtomicValue
-    def initialize(initial_value=nil)
+    def initialize(initial_value)
       @mu = Mutex.new
       set(initial_value)
     end

--- a/lib/nerve/atomic.rb
+++ b/lib/nerve/atomic.rb
@@ -1,0 +1,20 @@
+require 'thread'
+
+module Nerve
+  class AtomicValue
+    def initialize(initial_value=nil)
+      @mu = Mutex.new
+      set(initial_value)
+    end
+
+    def get
+      return @mu.synchronize { @value }
+    end
+
+    def set(new_value)
+      @mu.synchronize {
+        @value = new_value
+      }
+    end
+  end
+end

--- a/lib/nerve/reporter/zookeeper.rb
+++ b/lib/nerve/reporter/zookeeper.rb
@@ -114,12 +114,7 @@ class Nerve::Reporter
         return false
       else
         begin
-          node_stat = @zk.stat(@full_key || '/')
-
-          # renew_ttl does nothing if @node_ttl is not set.
-          renew_ttl(node_stat)
-
-          return node_stat.exists?
+          return @zk.exists?(@full_key || '/')
         rescue *ZK_CONNECTION_ERRORS => e
           log.error "nerve: error in ping reporter at zk node #{@full_key}: #{e.message}"
           return false

--- a/lib/nerve/reporter/zookeeper.rb
+++ b/lib/nerve/reporter/zookeeper.rb
@@ -31,8 +31,9 @@ class Nerve::Reporter
       @mode = (service['node_type'] || DEFAULT_NODE_TYPE).to_sym
       @zk_path = service['zk_path']
       @key_prefix = @zk_path + encode_child_name(service)
-      @full_key = nil
       @node_ttl = service['ttl_seconds']
+      @full_key = nil
+      @full_key_mu = Mutex.new
     end
 
     def start()
@@ -54,10 +55,16 @@ class Nerve::Reporter
         @zk = @@zk_pool[@zk_connection_string]
         log.info "nerve: retrieved zk connection to #{@zk_connection_string}"
       }
+
+      start_ttl_renew_thread
     end
 
     def stop()
-      log.info "nerve: removing zk node at #{@full_key}" if @full_key
+      stop_ttl_renew_thread
+
+      node_path = @full_key_mu.synchronize { @full_key }
+      log.info "nerve: removing zk node at #{node_path}" if node_path
+
       begin
         report_down
       ensure
@@ -77,14 +84,16 @@ class Nerve::Reporter
     end
 
     def report_up()
+      node_path = @full_key_mu.synchronize { @full_key }
+
       if not @zk.connected?
-        log.error "nerve: error in reporting up on zk node #{@full_key}: loss connection"
+        log.error "nerve: error in reporting up on zk node #{node_path}: loss connection"
         return false
       else
         begin
-          zk_save(@full_key)
+          zk_save(node_path)
         rescue *ZK_CONNECTION_ERRORS => e
-          log.error "nerve: error in reporting up on zk node #{@full_key}: #{e.message}"
+          log.error "nerve: error in reporting up on zk node #{node_path}: #{e.message}"
           return false
         end
 
@@ -93,14 +102,16 @@ class Nerve::Reporter
     end
 
     def report_down
+      node_path = @full_key_mu.synchronize { @full_key }
+
       if not @zk.connected?
-        log.error "nerve: error in reporting down on zk node #{@full_key}: loss connection"
+        log.error "nerve: error in reporting down on zk node #{node_path}: loss connection"
         return false
       else
         begin
           zk_delete
         rescue *ZK_CONNECTION_ERRORS => e
-          log.error "nerve: error in reporting down on zk node #{@full_key}: #{e.message}"
+          log.error "nerve: error in reporting down on zk node #{node_path}: #{e.message}"
           return false
         end
 
@@ -109,14 +120,16 @@ class Nerve::Reporter
     end
 
     def ping?
+      node_path = @full_key_mu.synchronize { @full_key }
+
       if not @zk.connected?
-        log.error "nerve: error in ping reporter at zk node #{@full_key}: loss connection"
+        log.error "nerve: error in ping reporter at zk node #{node_path}: loss connection"
         return false
       else
         begin
-          return @zk.exists?(@full_key || '/')
+          return @zk.exists?(node_path || '/')
         rescue *ZK_CONNECTION_ERRORS => e
-          log.error "nerve: error in ping reporter at zk node #{@full_key}: #{e.message}"
+          log.error "nerve: error in ping reporter at zk node #{node_path}: #{e.message}"
           return false
         end
       end
@@ -146,11 +159,16 @@ class Nerve::Reporter
     end
 
     def zk_delete
-      if @full_key
+      node_path = @full_key_mu.synchronize { @full_key }
+
+      if node_path
         statsd.time('nerve.reporter.zk.delete.elapsed_time', tags: ["zk_cluster:#{@zk_cluster}"]) do
-          @zk.delete(@full_key, :ignore => :no_node)
+          @zk.delete(node_path, :ignore => :no_node)
         end
-        @full_key = nil
+
+        @full_key_mu.synchronize {
+          @full_key = nil
+        }
       end
     end
 
@@ -158,38 +176,84 @@ class Nerve::Reporter
       # only mkdir_p if the path does not exist
       statsd.time('nerve.reporter.zk.create.elapsed_time', tags: ["zk_cluster:#{@zk_cluster}", "zk_path:#{@zk_path}"]) do
         @zk.mkdir_p(@zk_path) unless @zk.exists?(@zk_path)
-        @full_key = @zk.create(@key_prefix, :data => @data, :mode => @mode)
-        log.info "nerve: wrote new ZK node of type #{@mode} at #{@full_key}"
+        node_path = @zk.create(@key_prefix, :data => @data, :mode => @mode)
+
+        @full_key_mu.synchronize {
+          @full_key = node_path
+        }
+        log.info "nerve: wrote new ZK node of type #{@mode} at #{@node_path}"
       end
     end
 
-    def zk_save(exists)
-      return zk_create unless exists
+    def zk_save(node_path)
+      return zk_create unless node_path
 
       begin
         statsd.time('nerve.reporter.zk.save.elapsed_time', tags: ["zk_cluster:#{@zk_cluster}"]) do
-          @zk.set(@full_key, @data)
-          log.info "nerve: set data on #{@full_key}"
+          @zk.set(node_path, @data)
+          log.info "nerve: set data on #{node_path}"
         end
       rescue ZK::Exceptions::NoNode
         zk_create
       end
     end
 
-    # Renew TTL on the node by "touching" it. If the node exists, it will be
-    # written to with the same data. If it does not exist, it will be
-    # automatically be created.
-    # Note: ephemeral nodes are not written because they are managed by
-    # the session.
-    def renew_ttl(node_stat)
-      return if @node_ttl.nil?
+    def start_ttl_renew_thread
+      @ttl_should_exit = false
+      @ttl_thread = nil
 
-      node_exists = !node_stat.nil? && node_stat.exists?
-      return if node_exists && node_stat.ephemeral?
+      unless @node_ttl.nil? || @mode.to_s.start_with?('ephemeral')
+        @ttl_thread = Thread.new {
+          log.info "nerve: ttl renew: background thread starting"
+          last_run = Time.now - rand(@node_ttl)
 
-      if !node_exists || ((Time.now - node_stat.mtime_t) >= @node_ttl)
-        zk_save(node_exists)
+          until @ttl_should_exit
+            last_run = renew_ttl(last_run, Time.now)
+            sleep 0.5
+          end
+
+          log.info "synapse: ttl renew: background thread exiting normally"
+        }
       end
+    end
+
+    # Renew the TTL of @full_key if more than @node_ttl seconds has passed
+    # between `now` and `last_refresh`.
+    # Returns the last refresh time *after performing the renewal.*
+    # If the TTL *is* renewed, it will return `now`.
+    # Otherwise, it will return `last_refresh`.
+    def renew_ttl(last_refresh, now)
+      elapsed = now - last_refresh
+
+      if elapsed >= @node_ttl
+        node_path = @full_key_mu.synchronize { @full_key }
+
+        if node_path.nil?
+          log.info "nerve: ttl renew: not touching ZK node because path not set"
+        else
+          begin
+            @zk.set(node_path, @data)
+            log.info "nerve: ttl renew: touched ZK node at #{node_path}"
+            statsd.increment('nerve.reporter.zk.ttl.renew', tags: ["zk_cluster:#{@zk_cluster}", "result:success"])
+          rescue ::Zookeeper::Exceptions::NoNode
+            log.info "nerve: ttl renew: failed to touch ZK node because node not found"
+            statsd.increment('nerve.reporter.zk.ttl.renew', tags: ["zk_cluster:#{@zk_cluster}", "result:fail", "reason:no_node"])
+          end
+        end
+
+        # last_refresh can be set regardless of whether or not @zk.set is called.
+        # If @zk.set is called, then it's obvious that it should be set.
+        # If @zk.set is *not* called, it can only be called after @full_key
+        # is set, which happens when the node was just written.
+        return now
+      end
+
+      return last_refresh
+    end
+
+    def stop_ttl_renew_thread
+      @ttl_should_exit = true
+      @ttl_thread.join unless @ttl_thread.nil?
     end
   end
 end

--- a/lib/nerve/version.rb
+++ b/lib/nerve/version.rb
@@ -1,3 +1,3 @@
 module Nerve
-  VERSION = "0.9.5"
+  VERSION = "0.9.6"
 end

--- a/spec/lib/nerve/atomic_spec.rb
+++ b/spec/lib/nerve/atomic_spec.rb
@@ -1,0 +1,75 @@
+require 'spec_helper'
+require 'nerve/atomic'
+
+describe Nerve::AtomicValue do
+  let(:initial_value) { 'mock-value' }
+  let(:internal_mu) { subject.instance_variable_get(:@mu) }
+
+  subject { Nerve::AtomicValue.new(initial_value) }
+
+  describe '#initialize' do
+    it 'creates successfully' do
+      expect { subject }.not_to raise_error
+    end
+
+    it 'sets the initial value' do
+      expect(subject.get).to eq(initial_value)
+    end
+
+    context 'without a provided value' do
+      it 'defaults to nil' do
+        atom = Nerve::AtomicValue.new
+        expect(atom.get).to eq(nil)
+      end
+    end
+  end
+
+  describe '#get' do
+    let(:value) { 'new-value' }
+
+    before :each do
+      subject.instance_variable_set(:@value, value)
+    end
+
+    it 'returns the internal value' do
+      expect(subject.get).to eq(value)
+    end
+
+    it 'holds a lock' do
+      expect(internal_mu).to receive(:synchronize).exactly(:once)
+      subject.get
+    end
+
+    it 'releases lock after call' do
+      expect(internal_mu.locked?).to eq(false)
+      subject.get
+    end
+
+    context 'after a set' do
+      it 'returns the new value' do
+        subject.set(value)
+        expect(subject.get).to eq(value)
+      end
+    end
+  end
+
+  describe '#set' do
+    let(:value) { 'new-value' }
+
+    it 'sets the internal value' do
+      expect { subject.set(value) }
+        .to change { subject.instance_variable_get(:@value) }
+        .from(initial_value).to(value)
+    end
+
+    it 'holds a lock' do
+      expect(internal_mu).to receive(:synchronize).exactly(:once)
+      subject.set(value)
+    end
+
+    it 'releases lock after call' do
+      expect(internal_mu.locked?).to eq(false)
+      subject.set(value)
+    end
+  end
+end

--- a/spec/lib/nerve/atomic_spec.rb
+++ b/spec/lib/nerve/atomic_spec.rb
@@ -17,9 +17,8 @@ describe Nerve::AtomicValue do
     end
 
     context 'without a provided value' do
-      it 'defaults to nil' do
-        atom = Nerve::AtomicValue.new
-        expect(atom.get).to eq(nil)
+      it 'raises an error' do
+        expect { Nerve::AtomicValue.new }.to raise_error(ArgumentError)
       end
     end
   end

--- a/spec/lib/nerve/reporter_zookeeper_spec.rb
+++ b/spec/lib/nerve/reporter_zookeeper_spec.rb
@@ -282,7 +282,6 @@ describe Nerve::Reporter::Zookeeper do
         subject.instance_variable_set(:@key_prefix, path)
         subject.instance_variable_set(:@data, data)
         subject.instance_variable_set(:@mode, mode.to_sym)
-        subject.instance_variable_set(:@full_key, nil)
 
         allow(zk).to receive(:connected?).and_return(true)
         allow(zk).to receive(:exists?).with(parent_path).and_return(true)
@@ -337,7 +336,7 @@ describe Nerve::Reporter::Zookeeper do
     before :each do
       subject.instance_variable_set(:@zk, zk)
       subject.instance_variable_set(:@data, data)
-      subject.instance_variable_set(:@full_key, path) if node_exists
+      subject.instance_variable_get(:@full_key).set(path) if node_exists
       allow(zk).to receive(:exists?).and_return(node_exists)
       allow(zk).to receive(:connected?).and_return(zk_connected)
     end
@@ -414,8 +413,11 @@ describe Nerve::Reporter::Zookeeper do
 
   describe '#stop_ttl_renew_thread' do
     let(:thread) { double(Thread) }
+    let(:config) { base_config.merge({'ttl_seconds' => 10, 'node_type' => 'persistent'}) }
+
     before :each do
-      subject.instance_variable_set(:@ttl_thread, thread)
+      allow(Thread).to receive(:new).and_return(thread)
+      subject.send(:start_ttl_renew_thread)
     end
 
     it 'waits on the thread' do
@@ -448,7 +450,7 @@ describe Nerve::Reporter::Zookeeper do
 
     before :each do
       subject.instance_variable_set(:@zk, zk)
-      subject.instance_variable_set(:@full_key, path)
+      subject.instance_variable_get(:@full_key).set(path)
       subject.instance_variable_set(:@key_prefix, path)
       subject.instance_variable_set(:@data, data)
     end


### PR DESCRIPTION
## Summary
This essentially implements a heartbeat mechanism for `persistent` nodes, in order to keep the node's `mtime` up-to-date.

### Todo
- [x] manual testing
- [x] bump version
- [x] documentation for new option

## Testing
- [x] unit tests

For manual testing, I am verifying that:

1. The node appears in Zookeeper.
2. The node disappears automatically when Nerve is killed.
3. In TTL mode, the node is repeatedly "touched." This is detected with the node's `mtime` (last modified time). Without TTL mode, the `mtime` should remain the same as the `ctime`.

#### Existing behavior (ephemeral)
- [x] node is registered
```bash
+ zookeepercli -servers localhost:2181 -c ls /mango-test/services
base64_72_eyJob3N0IjoiMTI3LjAuMC4xIiwicG9ydCI6NjAwNywibmFtZSI6Im1hY2Jvb2stcHJvIn0=_0000000000
```
- [x] node is removed on exit
```bash
+ zookeepercli -servers localhost:2181 -c ls /mango-test/services

```
- [x] no `mtime` updates
```
ctime: 2020-03-19 13:02:56 -0400
mtime: 2020-03-19 13:02:56 -0400
```

#### Existing behavior (persistent): node is registered and automatically removed
- [x] node is registered
```bash
+ zookeepercli -servers localhost:2181 -c ls /mango-test/services
base64_72_eyJob3N0IjoiMTI3LjAuMC4xIiwicG9ydCI6NjAwNywibmFtZSI6Im1hY2Jvb2stcHJvIn0=_
```
- [x] node is removed on exit
```bash
+ zookeepercli -servers localhost:2181 -c ls /mango-test/services

```
- [x] no `mtime` updates
```
ctime: 2020-03-19 13:06:04 -0400
mtime: 2020-03-19 13:06:04 -0400
```

#### New behavior (ephemeral): node is registered but never touched
- [x] node is registered
```bash
+ zookeepercli -servers localhost:2181 -c ls /mango-test/services
base64_72_eyJob3N0IjoiMTI3LjAuMC4xIiwicG9ydCI6NjAwNywibmFtZSI6Im1hY2Jvb2stcHJvIn0=_0000000000
```
- [x] node is removed on exit
```bash
+ zookeepercli -servers localhost:2181 -c ls /mango-test/services

```
- [x] no `mtime` updates
```
ctime: 2020-03-19 13:06:51 -0400
mtime: 2020-03-19 13:06:51 -0400
```

#### New behavior (persistent): node is registered and `mtime` is updated periodically
- [x] node is registered
```bash
+ zookeepercli -servers localhost:2181 -c ls /mango-test/services
base64_72_eyJob3N0IjoiMTI3LjAuMC4xIiwicG9ydCI6NjAwNywibmFtZSI6Im1hY2Jvb2stcHJvIn0=_
```
- [x] node is removed on exit
```
+ zookeepercli -servers localhost:2181 -c ls /mango-test/services

```
- [x] `mtime` updates
```
# check 1
ctime: 2020-03-19 13:59:16 -0400
mtime: 2020-03-19 13:59:21 -0400

# check 2
ctime: 2020-03-19 13:59:16 -0400
mtime: 2020-03-19 13:59:31 -0400

# check 3:
ctime: 2020-03-19 13:59:16 -0400
mtime: 2020-03-19 13:59:41 -0400
```

*Nerve log*:
```
I, [2020-03-19T13:59:16.273885 #57404]  INFO -- Nerve::Reporter::Zookeeper: nerve: ttl renew: background thread starting
I, [2020-03-19T13:59:16.275529 #57404]  INFO -- Nerve::Reporter::Zookeeper: nerve: wrote new ZK node of type persistent at /mango-test/services/base64_72_eyJob3N0IjoiMTI3LjAuMC4xIiwicG9ydCI6NjAwNywibmFtZSI6Im1hY2Jvb2stcHJvIn0=_
I, [2020-03-19T13:59:16.275620 #57404]  INFO -- Nerve::ServiceWatcher: nerve: service mango-test_26009_secure is now up
I, [2020-03-19T13:59:21.296584 #57404]  INFO -- Nerve::Reporter::Zookeeper: nerve: ttl renew: touched ZK node at /mango-test/services/base64_72_eyJob3N0IjoiMTI3LjAuMC4xIiwicG9ydCI6NjAwNywibmFtZSI6Im1hY2Jvb2stcHJvIn0=_
I, [2020-03-19T13:59:31.328048 #57404]  INFO -- Nerve::Reporter::Zookeeper: nerve: ttl renew: touched ZK node at /mango-test/services/base64_72_eyJob3N0IjoiMTI3LjAuMC4xIiwicG9ydCI6NjAwNywibmFtZSI6Im1hY2Jvb2stcHJvIn0=_
I, [2020-03-19T13:59:41.367232 #57404]  INFO -- Nerve::Reporter::Zookeeper: nerve: ttl renew: touched ZK node at /mango-test/services/base64_72_eyJob3N0IjoiMTI3LjAuMC4xIiwicG9ydCI6NjAwNywibmFtZSI6Im1hY2Jvb2stcHJvIn0=_
```

#### New behavior (persistent): `mtime` is updated periodically when node already exists
- [x] node is not re-created
*Nerve log*
```
I, [2020-03-19T15:43:07.923040 #58055]  INFO -- Nerve::Reporter::Zookeeper: nerve: tried to write node but exists, setting data instead
```

```bash
+ zookeepercli -servers localhost:2181 -c ls /mango-test/services
0001.mango-test_
```
- [x] node is removed on exit
```bash
+ zookeepercli -servers localhost:2181 -c ls /mango-test/services

```
- [x] `mtime` updates
```
# check 1
ctime: 2020-03-19 15:43:07 -0400
mtime: 2020-03-19 15:43:12 -0400

# check 2
ctime: 2020-03-19 15:43:07 -0400
mtime: 2020-03-19 15:43:23 -0400

# check 3
ctime: 2020-03-19 15:43:07 -0400
mtime: 2020-03-19 15:43:33 -0400
```

*Nerve log*:
```
I, [2020-03-19T15:43:12.949821 #58055]  INFO -- Nerve::Reporter::Zookeeper: nerve: ttl renew: touched ZK node at /mango-test/services/0001.mango-test_
I, [2020-03-19T15:43:23.013111 #58055]  INFO -- Nerve::Reporter::Zookeeper: nerve: ttl renew: touched ZK node at /mango-test/services/0001.mango-test_
I, [2020-03-19T15:43:33.066686 #58055]  INFO -- Nerve::Reporter::Zookeeper: nerve: ttl renew: touched ZK node at /mango-test/services/0001.mango-test_
I, [2020-03-19T15:43:43.119609 #58055]  INFO -- Nerve::Reporter::Zookeeper: nerve: ttl renew: touched ZK node at /mango-test/services/0001.mango-test_
I, [2020-03-19T15:43:53.178126 #58055]  INFO -- Nerve::Reporter::Zookeeper: nerve: ttl renew: touched ZK node at /mango-test/services/0001.mango-test_
```

## Reviewers
@austin-zhu @bsherrod 
cc: @anson627 