### PR TITLE
Set explicit zk session timeout in nerve

### DIFF
--- a/lib/nerve/reporter/zookeeper.rb
+++ b/lib/nerve/reporter/zookeeper.rb
@@ -44,7 +44,9 @@ class Nerve::Reporter
       @@zk_pool_lock.synchronize {
         unless @@zk_pool.has_key?(@zk_connection_string)
           log.info "nerve: creating pooled connection to #{@zk_connection_string}"
-          @@zk_pool[@zk_connection_string] = ZK.new(@zk_connection_string, :timeout => 5)
+          # zk session timeout is 2 * receive_timeout_msec (as of zookeeper-1.4.x)
+          # i.e. 16000 means 32 sec session timeout
+          @@zk_pool[@zk_connection_string] = ZK.new(@zk_connection_string, :timeout => 5, :receive_timeout_msec => 16000)
           @@zk_pool_count[@zk_connection_string] = 1
           log.info "nerve: successfully created zk connection to #{@zk_connection_string}"
           statsd.increment('nerve.reporter.zk.client.created', tags: ["zk_cluster:#{@zk_cluster}"])

--- a/lib/nerve/version.rb
+++ b/lib/nerve/version.rb
@@ -1,3 +1,3 @@
 module Nerve
-  VERSION = "0.9.6"
+  VERSION = "0.9.7"
 end


### PR DESCRIPTION
### Summary

Current nerve does not specify explicit value for session timeout. By default ruby client uses RECEIVE_TIMEOUT=10000ms which leads to 20-sec session in zk server.

https://github.com/zk-ruby/zookeeper/blob/master/ext/c_zookeeper.rb#L20

The change adds receive_timeout_msec=16000 when creating zk client and will set session timeout to be 32-sec. This value will be different from other clients making it possible to identify nerve connections/sessions.

### Test
- unit tests: bundle exec rspec
- To verify that zk session is set to 32-sec, manual integration test was executed with zk server: 
  - created an instance of Nerve::Reporter::Zookeeper connecting to test zk server. 
  - use 4-letter commands to dump connections on zk server: `echo cons | nc localhost 2181 > cons.txt`
  - output shows that test connection has 32-sec session with to=32001: 
`/172.18.26.75:62059[1](queued=0,recved=3,sent=3,sid=0x66055392eb24038d,lop=CREA,est=1594229429532,to=32001,lcxid=0x5f0602b6,lzxid=0xb50009c930,lresp=22937508907,llat=0,minlat=0,avglat=0,maxlat=0)`



## Reviewers
@panchr 
@austin-zhu
@Jason-Jian 